### PR TITLE
hotfix/VectorMath/relaxes_overflow_on_inverse_hyperbolic_functions

### DIFF
--- a/docs/knowledges/mathematicals.md
+++ b/docs/knowledges/mathematicals.md
@@ -213,18 +213,45 @@ $$
 
 so that high precision and performace can consist with each other.
 
-## Hyperbolic and inverse hyperbolic functions
+## Hyperbolic functions
 
-Hyperbolic and inverse hyperbolic functions are defined following formulas, so that they can be calculated with elementary functions which are defined above:
+Hyperbolic functions are defined following formulas, so that they can be calculated with elementary functions which are defined above:
 
 $$
 \begin{aligned}
 \sinh x &= \cfrac{e^x - e^{-x}}{2}  \\
 \cosh x &= \cfrac{e^x + e^{-x}}{2}  \\
 \tanh x &= \cfrac{e^x - e^{-x}}{e^x + e^{-x}} = \cfrac{e^{2x} - 1}{e^{2x} + 1}  \\
+\end{aligned}
+$$
+
+## Inverse hyperbolic functions
+
+Inverse hyperbolic functions are defined following formulas, so that they can be calculated with elementary functions which are defined above:
+
+$$
+\begin{aligned}
 \mathrm{arsinh}\,x &= \ln(x + \sqrt{x^2+1})  \\
 \mathrm{arcosh}\,x &= \ln(x + \sqrt{x^2-1})  \\
 \mathrm{artanh}\,x &= \cfrac{1}{2}\ln\cfrac{1+x}{1-x}  \\
+\end{aligned}
+$$
+
+However, transformation of $\mathrm{arcsinh}$ and $\mathrm{arccosh}$ have computational overflow problem because of squared term.
+Therefore extra transformation such as following form is preferable:
+
+$$
+\begin{aligned}
+\mathrm{arsinh}\,x &= \ln(x + \sqrt{x^2+1})  \\
+                   &\sim \mathrm{Sign}(x) \ln(2|x|) \sim \mathrm{Sign}(x) (2 + \ln|x|) &(x \rightarrow \pm\infty)
+\end{aligned}
+$$
+
+$$
+\begin{aligned}
+\mathrm{arcosh}\,x &= \ln(x + \sqrt{x^2-1})  \\
+                   &= \ln\left\{x\left(1 + \frac{\sqrt{(x - 1)}\sqrt{(x + 1)}}{x}\right)\right\}  \\
+                   &= \ln x + \ln\left(1 + \frac{\sqrt{(x - 1)}\sqrt{(x + 1)}}{x}\right)
 \end{aligned}
 $$
 

--- a/src/SmartVectorDotNet/VectorMath/VectorMath._Acosh.cs
+++ b/src/SmartVectorDotNet/VectorMath/VectorMath._Acosh.cs
@@ -17,7 +17,17 @@ partial class VectorMath
     public static Vector<T> Acosh<T>(in Vector<T> x)
         where T : unmanaged
     {
-        var d = (x * x) - Acosh_<T>._1;
-        return Log(x + Sqrt(d));
+        // NOTE:
+        //    Generally `acosh` is expressed as:
+        //    $$
+        //    {\rm arccosh}\ x = \ln(x + \sqrt{x^2 - 1})
+        //    $$
+        //    But it may cause overflow for large `x`.
+        //    Therefore this implementation employs following formula:
+        //    $$
+        //    {\rm arccosh}\ x &= \ln\left\{x\left(1 + \cfrac{\sqrt{x^2 - 1}}{x}\right)\right\}  \\
+        //                     &= \ln\ x + \ln\left(1 + \cfrac{\sqrt{x - 1}\sqrt{x + 1}}{x}\right)
+        //    $$
+        return Log(Acosh_<T>._1 + Sqrt(x - Acosh_<T>._1) * Sqrt(x + Acosh_<T>._1) / x) + Log(x);
     }
 }

--- a/src/SmartVectorDotNet/VectorMath/VectorMath._Asinh.cs
+++ b/src/SmartVectorDotNet/VectorMath/VectorMath._Asinh.cs
@@ -3,7 +3,15 @@ using OP = VectorOp;
 using H = InternalHelpers;
 
 
-file class Asinh_<T> : VectorMath.Const<T> where T : unmanaged { }
+file class Asinh_<T> : VectorMath.Const<T> where T : unmanaged
+{
+    public static readonly Vector<T> Border =
+        typeof(T) == typeof(double)
+            ? H.Reinterpret<double, T>(new Vector<double>(1.35e+7))
+        : typeof(T) == typeof(float)
+            ? H.Reinterpret<float, T>(new Vector<float>(1.35e+7f))
+            : throw new ArgumentException();
+}
 
 
 partial class VectorMath
@@ -16,5 +24,24 @@ partial class VectorMath
     /// <returns></returns>
     public static Vector<T> Asinh<T>(in Vector<T> x)
         where T : unmanaged
-        => Log(x + Sqrt(x * x + Asinh_<T>._1));
+    {
+        // NOTE:
+        //    Generally `asinh` is expressed as:
+        //    $$
+        //    {\rm arcsinh}\ x = \ln(x + \sqrt{x^2 + 1})
+        //    $$
+        //    But it may cause overflow for large `x`.
+        //    Therefore this implementation employs following formula:
+        //    $$
+        //    \mathrm{arsinh}\,x &= \ln(x + \sqrt{x^2+1})  \\
+        //                       &\sim \mathrm{Sign}(x) \ln(2|x|) \sim \mathrm{Sign}(x) (2 + \ln|x|) &(x \rightarrow \pm\infty)
+        //    $$
+        var absX = Abs(x);
+        var sign = Sign(x);
+        return OP.ConditionalSelect(
+            OP.LessThan(absX, Asinh_<T>.Border),
+            Log(absX + Sqrt(x * x + Asinh_<T>._1)),
+            Asinh_<T>.Log_E_2 + Log(absX)
+            ) * sign;
+    }
 }


### PR DESCRIPTION
Improve implementation of following methods:

- `VectorMath.Asinh`
- `VectorMath.Acosh`