### PR TITLE
hotfix/make-secure-Unsafe

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.0",
+    "version": "10.0.101",
     "rollForward": "latestFeature"
   }
 }

--- a/src/SmartVectorDotNet.Generators.Internal/AnalyzerReleases.Shipped.md
+++ b/src/SmartVectorDotNet.Generators.Internal/AnalyzerReleases.Shipped.md
@@ -1,0 +1,7 @@
+# Release 0.1.2.0
+
+## New Rules
+
+Rule ID   | Category | Severity | Notes
+----------|----------|----------|------------
+SVINT1001 | Security | Error    | Unsafe APIs are required to be used within an `unsafe` context.

--- a/src/SmartVectorDotNet.Generators.Internal/GlobalConstants.cs
+++ b/src/SmartVectorDotNet.Generators.Internal/GlobalConstants.cs
@@ -1,0 +1,6 @@
+namespace SmartVectorDotNet.Generators.Internal;
+
+internal static class GlobalConstants
+{
+    public const string DiagnosticIDBase = "SVINT";
+}

--- a/src/SmartVectorDotNet.Generators.Internal/ParallelVectorizationGenerator.cs
+++ b/src/SmartVectorDotNet.Generators.Internal/ParallelVectorizationGenerator.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
 using Microsoft.CodeAnalysis;
 using SourceGeneratorToolkit;
 

--- a/src/SmartVectorDotNet.Generators.Internal/UnsafeContextAnalyzer.cs
+++ b/src/SmartVectorDotNet.Generators.Internal/UnsafeContextAnalyzer.cs
@@ -1,0 +1,69 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace SmartVectorDotNet.Generators.Internal;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+internal class UnsafeContextAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor _rule = new(
+        $"{GlobalConstants.DiagnosticIDBase}1001",
+        "Unsafe context required",
+        "Unsafe API `{0}` is required to be used within an `unsafe` context",
+        "Security",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        [_rule];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeUnsafeApiCall,
+            SyntaxKind.SimpleMemberAccessExpression);
+    }
+
+    private static void AnalyzeUnsafeApiCall(SyntaxNodeAnalysisContext context)
+    {
+        var member = context.SemanticModel.GetSymbolInfo(context.Node).Symbol;
+        if (member?.ContainingType is not { } typeSymbol)
+        {
+            return;
+        }
+
+        switch (typeSymbol.ToDisplayString())
+        {
+        case "System.Runtime.CompilerServices.Unsafe":
+        case "System.Runtime.InteropServices.MemoryMarshal":
+            break;
+        default:
+            // Not an unsafe API
+            return;
+        }
+
+        foreach(var ancestor in context.Node.Ancestors())
+        {
+            if (ancestor is UnsafeStatementSyntax)
+            {
+                // Already in an unsafe context
+                return;
+            }
+            if(ancestor is MethodDeclarationSyntax methodDeclaration
+                && methodDeclaration.ChildTokens().Any(static token => token.IsKind(SyntaxKind.UnsafeKeyword)))
+            {
+                // Already in an unsafe context
+                return;
+            }
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            _rule,
+            context.Node.GetLocation(),
+            member.ToDisplayString()));
+    }
+}

--- a/src/SmartVectorDotNet.Generators.Internal/UnsafeContextAnalyzer.cs
+++ b/src/SmartVectorDotNet.Generators.Internal/UnsafeContextAnalyzer.cs
@@ -25,7 +25,7 @@ internal class UnsafeContextAnalyzer : DiagnosticAnalyzer
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
         context.RegisterSyntaxNodeAction(AnalyzeUnsafeApiCall,
-            SyntaxKind.SimpleMemberAccessExpression);
+            SyntaxKind.InvocationExpression);
     }
 
     private static void AnalyzeUnsafeApiCall(SyntaxNodeAnalysisContext context)
@@ -35,6 +35,7 @@ internal class UnsafeContextAnalyzer : DiagnosticAnalyzer
         {
             return;
         }
+        if (!member.Name.Contains("GatherCore")) { return; }
 
         switch (typeSymbol.ToDisplayString())
         {
@@ -42,6 +43,13 @@ internal class UnsafeContextAnalyzer : DiagnosticAnalyzer
         case "System.Runtime.InteropServices.MemoryMarshal":
             break;
         default:
+            var name = member.Name;
+            TextWriter.Null.WriteLine(name);
+            if(member.GetAttributes().Any(static attr => attr.AttributeClass?.ToDisplayString() == "SmartVectorDotNet.UnsafeApiAttribute"))
+            {
+                // UnsafeApiAttribute indicates that the type is unsafe
+                break;
+            }
             // Not an unsafe API
             return;
         }

--- a/src/SmartVectorDotNet.Generators.Internal/UnsafeContextAnalyzer.cs
+++ b/src/SmartVectorDotNet.Generators.Internal/UnsafeContextAnalyzer.cs
@@ -35,7 +35,6 @@ internal class UnsafeContextAnalyzer : DiagnosticAnalyzer
         {
             return;
         }
-        if (!member.Name.Contains("GatherCore")) { return; }
 
         switch (typeSymbol.ToDisplayString())
         {
@@ -43,8 +42,6 @@ internal class UnsafeContextAnalyzer : DiagnosticAnalyzer
         case "System.Runtime.InteropServices.MemoryMarshal":
             break;
         default:
-            var name = member.Name;
-            TextWriter.Null.WriteLine(name);
             if(member.GetAttributes().Any(static attr => attr.AttributeClass?.ToDisplayString() == "SmartVectorDotNet.UnsafeApiAttribute"))
             {
                 // UnsafeApiAttribute indicates that the type is unsafe
@@ -63,6 +60,12 @@ internal class UnsafeContextAnalyzer : DiagnosticAnalyzer
             }
             if(ancestor is MethodDeclarationSyntax methodDeclaration
                 && methodDeclaration.ChildTokens().Any(static token => token.IsKind(SyntaxKind.UnsafeKeyword)))
+            {
+                // Already in an unsafe context
+                return;
+            }
+            if(ancestor is LocalFunctionStatementSyntax localFuncDecl
+                && localFuncDecl.ChildTokens().Any(static token => token.IsKind(SyntaxKind.UnsafeKeyword)))
             {
                 // Already in an unsafe context
                 return;

--- a/src/SmartVectorDotNet/Guard.cs
+++ b/src/SmartVectorDotNet/Guard.cs
@@ -1,11 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace SmartVectorDotNet;
+using CAEAttribute = CallerArgumentExpressionAttribute;
 
 /// <summary>
 /// Provides a set of methods to guard against invalid arguments, states, and conditions.
@@ -13,195 +11,250 @@ namespace SmartVectorDotNet;
 /// <remarks>
 /// This class is set to public to support generators, and it is not recommended to use it directly from user code.
 /// </remarks>
-[Browsable(false)]
-[EditorBrowsable(EditorBrowsableState.Never)]
 public static class Guard
 {
-    /// <summary>
-    /// Ensures that the specified value is not null.
-    /// </summary>
+    private const MethodImplOptions _inlining = MethodImplOptions.AggressiveInlining;
+
+    #region NotNull
+
+    /// <summary> Ensures that the specified value is not null. </summary>
     /// <typeparam name="T"></typeparam>
     /// <param name="valueShouldBeNotNull"></param>
     /// <param name="parameterName"></param>
     /// <exception cref="ArgumentNullException"></exception>
-    [DebuggerHidden]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void NotNull<T>(T valueShouldBeNotNull, [CallerArgumentExpression(nameof(valueShouldBeNotNull))] string parameterName = null!)
+    [DebuggerHidden, MethodImpl(_inlining)]
+    public static T NotNull<T>([NotNull] T? valueShouldBeNotNull, [CAE(nameof(valueShouldBeNotNull))] string parameterName = null!)
     {
         if (valueShouldBeNotNull is null)
         {
             throw new ArgumentNullException(parameterName);
         }
+        return valueShouldBeNotNull;
     }
 
-    /// <summary>
-    /// Ensures that the specified string value is not null or empty.
-    /// </summary>
-    /// <param name="valueShouldBeNotNullAndNotEmpty"></param>
+    /// <inheritdoc cref="NotNull{T}(T, string)"/>
+    [DebuggerHidden, MethodImpl(_inlining), Conditional("DEBUG")]
+    public static void DebugNotNull<T>([NotNull] T? valueShouldBeNotNull, [CAE(nameof(valueShouldBeNotNull))] string parameterName = null!) =>
+        NotNull(valueShouldBeNotNull, parameterName);
+
+    #endregion NotNull
+
+
+    #region NotNullNorEmpty
+
+    /// <summary> Ensures that the specified string value is not null or empty. </summary>
+    /// <param name="valueShouldBeNotNullNorEmpty"></param>
     /// <param name="parameterName"></param>
     /// <exception cref="ArgumentException"></exception>
-    [DebuggerHidden]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void NotNullOrEmpty(string valueShouldBeNotNullAndNotEmpty, [CallerArgumentExpression(nameof(valueShouldBeNotNullAndNotEmpty))] string parameterName = null!)
+    [DebuggerHidden, MethodImpl(_inlining)]
+    public static string NotNullNorEmpty(string? valueShouldBeNotNullNorEmpty, [CAE(nameof(valueShouldBeNotNullNorEmpty))] string parameterName = null!)
     {
-        if (string.IsNullOrEmpty(valueShouldBeNotNullAndNotEmpty))
+        if (string.IsNullOrEmpty(valueShouldBeNotNullNorEmpty))
         {
             throw new ArgumentException("Value cannot be null or empty.", parameterName);
         }
+        return valueShouldBeNotNullNorEmpty!;
     }
 
-    /// <summary>
-    /// Ensures that the specified string value is not null or whitespace.
-    /// </summary>
+    /// <inheritdoc cref="NotNullNorEmpty(string, string)"/>
+    [DebuggerHidden, MethodImpl(_inlining), Conditional("DEBUG")]
+    public static void DebugNotNullNorEmpty([NotNull] string? valueShouldBeNotNullNorEmpty, [CAE(nameof(valueShouldBeNotNullNorEmpty))] string parameterName = null!) =>
+        #pragma warning disable IDE0079
+        #pragma warning disable CS8777
+        NotNullNorEmpty(valueShouldBeNotNullNorEmpty, parameterName);
+        #pragma warning restore CS8777
+        #pragma warning restore IDE0079
+
+    #endregion NotNullNorEmpty
+
+
+    #region NotNullNorWhiteSpace
+
+    /// <summary> Ensures that the specified string value is not null or whitespace. </summary>
     /// <param name="valueShouldBeNotNullAndNotWhiteSpace"></param>
     /// <param name="parameterName"></param>
     /// <exception cref="ArgumentException"></exception>
-    [DebuggerHidden]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void NotNullOrWhiteSpace(string valueShouldBeNotNullAndNotWhiteSpace, [CallerArgumentExpression(nameof(valueShouldBeNotNullAndNotWhiteSpace))] string parameterName = null!)
+    [DebuggerHidden, MethodImpl(_inlining)]
+    public static string NotNullNorWhiteSpace([NotNull] string? valueShouldBeNotNullAndNotWhiteSpace, [CAE(nameof(valueShouldBeNotNullAndNotWhiteSpace))] string parameterName = null!)
     {
         if (string.IsNullOrWhiteSpace(valueShouldBeNotNullAndNotWhiteSpace))
         {
             throw new ArgumentException("Value cannot be null or whitespace.", parameterName);
         }
+        #pragma warning disable IDE0079
+        #pragma warning disable CS8777
+        return valueShouldBeNotNullAndNotWhiteSpace!;
+        #pragma warning restore CS8777
+        #pragma warning restore IDE0079
     }
 
-    /// <summary>
-    /// Ensures that the specified value is not negative.
-    /// </summary>
+    /// <inheritdoc cref="NotNullNorWhiteSpace(string, string)"/>
+    [DebuggerHidden, MethodImpl(_inlining), Conditional("DEBUG")]
+    public static void DebugNotNullNorWhiteSpace([NotNull] string? valueShouldBeNotNullAndNotWhiteSpace, [CAE(nameof(valueShouldBeNotNullAndNotWhiteSpace))] string parameterName = null!) =>
+        NotNullNorWhiteSpace(valueShouldBeNotNullAndNotWhiteSpace, parameterName);
+
+    #endregion NotNullNorWhiteSpace
+
+
+    #region NotNegative
+
+    /// <summary> Ensures that the specified value is not negative. </summary>
     /// <param name="valueShouldBeNotNegative"></param>
     /// <param name="parameterName"></param>
+    /// <returns></returns>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
-    [DebuggerHidden]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void NotNegative(int valueShouldBeNotNegative, [CallerArgumentExpression(nameof(valueShouldBeNotNegative))] string parameterName = null!)
+    [DebuggerHidden, MethodImpl(_inlining)]
+    public static int NotNegative(int valueShouldBeNotNegative, [CAE(nameof(valueShouldBeNotNegative))] string parameterName = null!)
     {
         if (valueShouldBeNotNegative < 0)
         {
             throw new ArgumentOutOfRangeException(parameterName, "Value cannot be negative.");
         }
+        return valueShouldBeNotNegative;
     }
 
-    /// <summary>
-    /// Ensures that the specified value is not negative.
-    /// </summary>
-    /// <param name="valueShouldBeNotNegative"></param>
-    /// <param name="parameterName"></param>
-    /// <exception cref="ArgumentOutOfRangeException"></exception>
-    [DebuggerHidden]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void NotNegative(long valueShouldBeNotNegative, [CallerArgumentExpression(nameof(valueShouldBeNotNegative))] string parameterName = null!)
+    /// <inheritdoc cref="NotNegative(int, string)"/>
+    [DebuggerHidden, MethodImpl(_inlining), Conditional("DEBUG")]
+    public static void DebugNotNegative(int valueShouldBeNotNegative, [CAE(nameof(valueShouldBeNotNegative))] string parameterName = null!) =>
+        NotNegative(valueShouldBeNotNegative, parameterName);
+
+
+    /// <inheritdoc cref="NotNegative(int, string)"/>
+    [DebuggerHidden, MethodImpl(_inlining)]
+    public static long NotNegative(long valueShouldBeNotNegative, [CAE(nameof(valueShouldBeNotNegative))] string parameterName = null!)
     {
         if (valueShouldBeNotNegative < 0)
         {
             throw new ArgumentOutOfRangeException(parameterName, "Value cannot be negative.");
         }
+        return valueShouldBeNotNegative;
     }
 
-    /// <summary>
-    /// Ensures that the specified value is not negative.
-    /// </summary>
-    /// <param name="valueShouldBeNotNegative"></param>
-    /// <param name="parameterName"></param>
-    /// <exception cref="ArgumentOutOfRangeException"></exception>
-    [DebuggerHidden]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void NotNegative(float valueShouldBeNotNegative, [CallerArgumentExpression(nameof(valueShouldBeNotNegative))] string parameterName = null!)
+    /// <inheritdoc cref="NotNegative(int, string)"/>
+    [DebuggerHidden, MethodImpl(_inlining), Conditional("DEBUG")]
+    public static void DebugNotNegative(long valueShouldBeNotNegative, [CAE(nameof(valueShouldBeNotNegative))] string parameterName = null!) =>
+        NotNegative(valueShouldBeNotNegative, parameterName);
+
+
+    /// <inheritdoc cref="NotNegative(int, string)"/>
+    [DebuggerHidden, MethodImpl(_inlining)]
+    public static float NotNegative(float valueShouldBeNotNegative, [CAE(nameof(valueShouldBeNotNegative))] string parameterName = null!)
     {
         if (valueShouldBeNotNegative < 0)
         {
             throw new ArgumentOutOfRangeException(parameterName, "Value cannot be negative.");
         }
+        return valueShouldBeNotNegative;
     }
 
-    /// <summary>
-    /// Ensures that the specified value is not negative.
-    /// </summary>
-    /// <param name="valueShouldBeNotNegative"></param>
-    /// <param name="parameterName"></param>
-    /// <exception cref="ArgumentOutOfRangeException"></exception>
-    [DebuggerHidden]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void NotNegative(double valueShouldBeNotNegative, [CallerArgumentExpression(nameof(valueShouldBeNotNegative))] string parameterName = null!)
+    /// <inheritdoc cref="NotNegative(int, string)" />
+    [DebuggerHidden, MethodImpl(_inlining), Conditional("DEBUG")]
+    public static void DebugNotNegative(float valueShouldBeNotNegative, [CAE(nameof(valueShouldBeNotNegative))] string parameterName = null!) =>
+        NotNegative(valueShouldBeNotNegative, parameterName);
+
+
+    /// <inheritdoc cref="NotNegative(int, string)"/>
+    [DebuggerHidden, MethodImpl(_inlining)]
+    public static double NotNegative(double valueShouldBeNotNegative, [CAE(nameof(valueShouldBeNotNegative))] string parameterName = null!)
     {
         if (valueShouldBeNotNegative < 0)
         {
             throw new ArgumentOutOfRangeException(parameterName, "Value cannot be negative.");
         }
+        return valueShouldBeNotNegative;
     }
 
-    /// <summary>
-    /// Ensures that the specified value is not negative.
-    /// </summary>
-    /// <param name="valueShouldBeNotNegative"></param>
-    /// <param name="parameterName"></param>
-    /// <exception cref="ArgumentOutOfRangeException"></exception>
-    [DebuggerHidden]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void NotNegative(decimal valueShouldBeNotNegative, [CallerArgumentExpression(nameof(valueShouldBeNotNegative))] string parameterName = null!)
-    {
-        if (valueShouldBeNotNegative < 0)
-        {
-            throw new ArgumentOutOfRangeException(parameterName, "Value cannot be negative.");
-        }
-    }
+    /// <inheritdoc cref="NotNegative(int, string)"/>
+    [DebuggerHidden, MethodImpl(_inlining), Conditional("DEBUG")]
+    public static void DebugNotNegative(double valueShouldBeNotNegative, [CAE(nameof(valueShouldBeNotNegative))] string parameterName = null!) =>
+        NotNegative(valueShouldBeNotNegative, parameterName);
 
-    /// <summary>
-    /// Ensures that the specified value is not zero.
-    /// </summary>
+    #endregion NotNegative
+
+
+    #region NotZero
+
+    /// <summary> Ensures that the specified value is not zero. </summary>
     /// <param name="valueShouldBeNotZero"></param>
     /// <param name="parameterName"></param>
+    /// <returns></returns>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
-    [DebuggerHidden]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void NotZero(int valueShouldBeNotZero, [CallerArgumentExpression(nameof(valueShouldBeNotZero))] string parameterName = null!)
+    [DebuggerHidden, MethodImpl(_inlining)]
+    public static int NotZero(int valueShouldBeNotZero, [CAE(nameof(valueShouldBeNotZero))] string parameterName = null!)
     {
         if (valueShouldBeNotZero == 0)
         {
             throw new ArgumentOutOfRangeException(parameterName, "Value cannot be zero.");
         }
+        return valueShouldBeNotZero;
     }
 
-    /// <summary>
-    /// Ensures that the specified value is not zero.
-    /// </summary>
-    /// <param name="valueShouldBeNotZero"></param>
-    /// <param name="parameterName"></param>
-    /// <exception cref="ArgumentOutOfRangeException"></exception>
-    [DebuggerHidden]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void NotZero(long valueShouldBeNotZero, [CallerArgumentExpression(nameof(valueShouldBeNotZero))] string parameterName = null!)
+    /// <inheritdoc cref="NotZero(int, string)"/>
+    [DebuggerHidden, MethodImpl(_inlining), Conditional("DEBUG")]
+    public static void DebugNotZero(int valueShouldBeNotZero, [CAE(nameof(valueShouldBeNotZero))] string parameterName = null!) =>
+        NotZero(valueShouldBeNotZero, parameterName);
+
+
+    /// <inheritdoc cref="NotZero(int, string)"/>
+    [DebuggerHidden, MethodImpl(_inlining)]
+    public static long NotZero(long valueShouldBeNotZero, [CAE(nameof(valueShouldBeNotZero))] string parameterName = null!)
     {
         if (valueShouldBeNotZero == 0)
         {
             throw new ArgumentOutOfRangeException(parameterName, "Value cannot be zero.");
         }
+        return valueShouldBeNotZero;
     }
 
-    /// <summary>
-    /// Ensures that the specified value is not zero.
-    /// </summary>
-    /// <param name="valueShouldBeNotZero"></param>
-    /// <param name="parameterName"></param>
-    /// <exception cref="ArgumentOutOfRangeException"></exception>
-    [DebuggerHidden]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void NotZero(float valueShouldBeNotZero, [CallerArgumentExpression(nameof(valueShouldBeNotZero))] string parameterName = null!)
+    /// <inheritdoc cref="NotZero(int, string)"/>
+    [DebuggerHidden, MethodImpl(_inlining), Conditional("DEBUG")]
+    public static void DebugNotZero(long valueShouldBeNotZero, [CAE(nameof(valueShouldBeNotZero))] string parameterName = null!) =>
+        NotZero(valueShouldBeNotZero, parameterName);
+
+
+    /// <inheritdoc cref="NotZero(int, string)"/>
+    [DebuggerHidden, MethodImpl(_inlining)]
+    public static float NotZero(float valueShouldBeNotZero, [CAE(nameof(valueShouldBeNotZero))] string parameterName = null!)
     {
         if (valueShouldBeNotZero == 0)
         {
             throw new ArgumentOutOfRangeException(parameterName, "Value cannot be zero.");
         }
+        return valueShouldBeNotZero;
     }
 
-    /// <summary>
-    /// Ensures that the condition is satisfied, or throws <see cref="ArgumentOutOfRangeException"/>.
-    /// </summary>
+    /// <inheritdoc cref="NotZero(int, string)"/>
+    [DebuggerHidden, MethodImpl(_inlining), Conditional("DEBUG")]
+    public static void DebugNotZero(float valueShouldBeNotZero, [CAE(nameof(valueShouldBeNotZero))] string parameterName = null!) =>
+        NotZero(valueShouldBeNotZero, parameterName);
+
+
+    /// <inheritdoc cref="NotZero(int, string)"/>
+    [DebuggerHidden, MethodImpl(_inlining)]
+    public static double NotZero(double valueShouldBeNotZero, [CAE(nameof(valueShouldBeNotZero))] string parameterName = null!)
+    {
+        if (valueShouldBeNotZero == 0)
+        {
+            throw new ArgumentOutOfRangeException(parameterName, "Value cannot be zero.");
+        }
+        return valueShouldBeNotZero;
+    }
+
+    /// <inheritdoc cref="NotZero(int, string)"/>
+    [DebuggerHidden, MethodImpl(_inlining), Conditional("DEBUG")]
+    public static void DebugNotZero(double valueShouldBeNotZero, [CAE(nameof(valueShouldBeNotZero))] string parameterName = null!) =>
+        NotZero(valueShouldBeNotZero, parameterName);
+
+    #endregion NotZero
+
+
+    #region ValidRange
+
+    /// <summary> Ensures that the condition is satisfied, or throws <see cref="ArgumentOutOfRangeException"/>. </summary>
     /// <param name="shouldBe"></param>
     /// <param name="message"></param>
     /// <exception cref="ArgumentOutOfRangeException"></exception>
-    [DebuggerHidden]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [DebuggerHidden, MethodImpl(_inlining)]
     public static void ValidRange(bool shouldBe, string message)
     {
         if (!shouldBe)
@@ -210,14 +263,21 @@ public static class Guard
         }
     }
 
-    /// <summary>
-    /// Ensures that the condition is satisfied, or throws <see cref="ArgumentException"/>.
-    /// </summary>
+    /// <inheritdoc cref="ValidRange(bool, string)" />
+    [DebuggerHidden, MethodImpl(_inlining), Conditional("DEBUG")]
+    public static void DebugValidRange(bool shouldBe, string message) =>
+        ValidRange(shouldBe, message);
+
+    #endregion ValidRange
+
+
+    #region ValidArgument
+
+    /// <summary> Ensures that the condition is satisfied, or throws <see cref="ArgumentException"/>. </summary>
     /// <param name="shouldBe"></param>
     /// <param name="message"></param>
     /// <exception cref="ArgumentException"></exception>
-    [DebuggerHidden]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [DebuggerHidden, MethodImpl(_inlining)]
     public static void ValidArgument(bool shouldBe, string message)
     {
         if (!shouldBe)
@@ -226,14 +286,21 @@ public static class Guard
         }
     }
 
-    /// <summary>
-    /// Ensures that the condition is satisfied, or throws <see cref="InvalidOperationException"/>.
-    /// </summary>
+    /// <inheritdoc cref="ValidArgument(bool, string)" />
+    [DebuggerHidden, MethodImpl(_inlining), Conditional("DEBUG")]
+    public static void DebugValidArgument(bool shouldBe, string message) =>
+        ValidArgument(shouldBe, message);
+
+    #endregion ValidArgument
+
+
+    #region ValidState
+
+    /// <summary> Ensures that the condition is satisfied, or throws <see cref="InvalidOperationException"/>. </summary>
     /// <param name="shouldBe"></param>
     /// <param name="message"></param>
     /// <exception cref="InvalidOperationException"></exception>
-    [DebuggerHidden]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [DebuggerHidden, MethodImpl(_inlining)]
     public static void ValidState(bool shouldBe, string message)
     {
         if (!shouldBe)
@@ -242,13 +309,20 @@ public static class Guard
         }
     }
 
-    /// <summary>
-    /// Ensures that the specified type is a primitive real number type (float or double).
-    /// </summary>
+    /// <inheritdoc cref="ValidState(bool, string)" />
+    [DebuggerHidden, MethodImpl(_inlining), Conditional("DEBUG")]
+    public static void DebugValidState(bool shouldBe, string message) =>
+        ValidState(shouldBe, message);
+
+    #endregion ValidState
+
+
+    #region OnlyRealSupported
+
+    /// <summary> Ensures that the specified type is a primitive real number type (float or double). </summary>
     /// <typeparam name="TShouldBeReal"></typeparam>
     /// <exception cref="NotSupportedException"></exception>
-    [DebuggerHidden]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [DebuggerHidden, MethodImpl(_inlining)]
     public static void OnlyRealSupported<TShouldBeReal>()
         where TShouldBeReal : unmanaged
     {
@@ -257,4 +331,18 @@ public static class Guard
             throw new NotSupportedException();
         }
     }
+
+    /// <inheritdoc cref="OnlyRealSupported{TShouldBeReal}" />
+    [DebuggerHidden, MethodImpl(_inlining), Conditional("DEBUG")]
+    public static void DebugOnlyRealSupported<TShouldBeReal>()
+        where TShouldBeReal : unmanaged
+    {
+        if (typeof(TShouldBeReal) != typeof(float) && typeof(TShouldBeReal) != typeof(double))
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    #endregion OnlyRealSupported
+
 }

--- a/src/SmartVectorDotNet/InternalHelpers.cs
+++ b/src/SmartVectorDotNet/InternalHelpers.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
 #if NETCOREAPP3_0_OR_GREATER
 using System.Runtime.Intrinsics;
 #endif
@@ -13,6 +9,15 @@ namespace SmartVectorDotNet;
 internal static class InternalHelpers
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int SizeOf<T>()
+    {
+        unsafe
+        {
+            return Unsafe.SizeOf<T>();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Vector<T> CreateVector<T>(Span<T> elements)
         where T : unmanaged
         => CreateVector((ReadOnlySpan<T>)elements);
@@ -21,8 +26,30 @@ internal static class InternalHelpers
     public static Vector<T> CreateVector<T>(ReadOnlySpan<T> elements)
         where T : unmanaged
     {
-        return MemoryMarshal.Cast<T, Vector<T>>(elements)[0];
+        Guard.DebugValidArgument(
+            elements.Length >= Vector<T>.Count,
+            $"The length of elements span must be at least {Vector<T>.Count} for creating {nameof(Vector<>)}.");
+        unsafe
+        {
+            return MemoryMarshal.Cast<T, Vector<T>>(elements)[0];
+        }
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsSameBuffer<T1, T2>(ReadOnlySpan<T1> source, Span<T2> destination)
+        where T1 : unmanaged
+        where T2 : unmanaged
+    {
+        unsafe
+        {
+            return SizeOf<T1>() == SizeOf<T2>()
+                && Unsafe.ByteOffset(
+                    ref Unsafe.As<T1, byte>(ref Unsafe.AsRef(in source[0])),
+                    ref Unsafe.As<T2, byte>(ref destination[0])) == IntPtr.Zero;
+        }
+    }
+
+
 
 #if NET6_0_OR_GREATER
 
@@ -35,7 +62,13 @@ internal static class InternalHelpers
     public static Vector128<T> CreateVector128<T>(ReadOnlySpan<T> elements)
         where T : unmanaged
     {
-        return MemoryMarshal.Cast<T, Vector128<T>>(elements)[0];
+        Guard.DebugValidArgument(
+            elements.Length >= Vector128<T>.Count,
+            $"The length of elements span must be at least {Vector128<T>.Count} for creating {nameof(Vector128<>)}.");
+        unsafe
+        {
+            return MemoryMarshal.Cast<T, Vector128<T>>(elements)[0];
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -47,150 +80,231 @@ internal static class InternalHelpers
     public static Vector256<T> CreateVector256<T>(ReadOnlySpan<T> elements)
         where T : unmanaged
     {
-        return MemoryMarshal.Cast<T, Vector256<T>>(elements)[0];
+        Guard.DebugValidArgument(
+            elements.Length >= Vector256<T>.Count,
+            $"The length of elements span must be at least {Vector256<T>.Count} for creating {nameof(Vector256<>)}.");
+        unsafe
+        {
+            return MemoryMarshal.Cast<T, Vector256<T>>(elements)[0];
+        }
     }
 
 #endif
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly TTo Reinterpret<TFrom, TTo>(in TFrom x)
-        => ref Unsafe.As<TFrom, TTo>(ref Unsafe.AsRef(in x));
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref TTo ReinterpretMutable<TFrom, TTo>(ref TFrom x)
-        => ref Unsafe.As<TFrom, TTo>(ref x);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<TTo> Reinterpret<TFrom, TTo>(in Vector<TFrom> x)
+    public static TTo BitCast<TFrom, TTo>(TFrom x)
         where TFrom : unmanaged
         where TTo : unmanaged
-        => ref Unsafe.As<Vector<TFrom>, Vector<TTo>>(ref Unsafe.AsRef(in x));
+    {
+#if NET8_0_OR_GREATER
+        unsafe
+        {
+            return Unsafe.BitCast<TFrom, TTo>(x);
+        }
+#else
+        Guard.DebugValidArgument(
+            SizeOf<TFrom>() == SizeOf<TTo>(), 
+            $"Cannot reinterpret from {typeof(TFrom)} to {typeof(TTo)} because their sizes are different.");
+        unsafe
+        {
+            return Unsafe.As<TFrom, TTo>(ref Unsafe.AsRef(in x));
+        }
+#endif
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref Vector<TTo> ReinterpretMutable<TFrom, TTo>(ref Vector<TFrom> x)
+    public static ref TTo Reinterpret<TFrom, TTo>(ref TFrom x)
         where TFrom : unmanaged
         where TTo : unmanaged
-        => ref Unsafe.As<Vector<TFrom>, Vector<TTo>>(ref x);
+    {
+        Guard.DebugValidArgument(
+            SizeOf<TFrom>() == SizeOf<TTo>(),
+            $"Cannot reinterpret from {typeof(TFrom)} to {typeof(TTo)} because their sizes are different.");
+        unsafe
+        {
+            return ref Unsafe.As<TFrom, TTo>(ref x);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector<TTo> BitCastV<TFrom, TTo>(Vector<TFrom> x)
+        where TFrom : unmanaged
+        where TTo : unmanaged
+    {
+#if NET8_0_OR_GREATER
+        unsafe
+        {
+            return Unsafe.BitCast<Vector<TFrom>, Vector<TTo>>(x);
+        }
+#else
+        unsafe
+        {
+            return Unsafe.As<Vector<TFrom>, Vector<TTo>>(ref Unsafe.AsRef(in x));
+        }
+#endif
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ref Vector<TTo> ReinterpretV<TFrom, TTo>(ref Vector<TFrom> x)
+        where TFrom : unmanaged
+        where TTo : unmanaged
+    {
+        unsafe
+        {
+            return ref Unsafe.As<Vector<TFrom>, Vector<TTo>>(ref x);
+        }
+    }
 
 #if NET6_0_OR_GREATER
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector128<TTo> Reinterpret<TFrom, TTo>(in Vector128<TFrom> x)
+    public static Vector128<TTo> BitCast<TFrom, TTo>(Vector128<TFrom> x)
         where TFrom : unmanaged
         where TTo : unmanaged
-        => ref Unsafe.As<Vector128<TFrom>, Vector128<TTo>>(ref Unsafe.AsRef(in x));
+    {
+#if NET8_0_OR_GREATER
+        unsafe
+        {
+            return Unsafe.BitCast<Vector128<TFrom>, Vector128<TTo>>(x);
+        }
+#else
+        unsafe
+        {
+            return Unsafe.As<Vector128<TFrom>, Vector128<TTo>>(ref Unsafe.AsRef(in x));
+        }
+#endif
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector256<TTo> Reinterpret<TFrom, TTo>(in Vector256<TFrom> x)
+    public static Vector256<TTo> BitCast<TFrom, TTo>(Vector256<TFrom> x)
         where TFrom : unmanaged
         where TTo : unmanaged
-        => ref Unsafe.As<Vector256<TFrom>, Vector256<TTo>>(ref Unsafe.AsRef(in x));
+    {
+#if NET8_0_OR_GREATER
+        unsafe
+        {
+            return Unsafe.BitCast<Vector256<TFrom>, Vector256<TTo>>(x);
+        }
+#else
+        unsafe
+        {
+            return ref Unsafe.As<Vector256<TFrom>, Vector256<TTo>>(ref Unsafe.AsRef(in x));
+        }
+#endif
+    }
 
 #endif
 
-    /// <remarks>
-    /// This method is only for generic type conversion where actual type parameter is same with closed type parameter.
-    /// </remarks>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<TTo>[] ReinterpretVArray<TFrom, TTo>(in Vector<TFrom>[] x)
+        /// <remarks>
+        /// This method is only for generic type conversion where actual type parameter is same with closed type parameter.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector<TTo>[] ReinterpretVArray<TFrom, TTo>(Vector<TFrom>[] x)
         where TFrom : unmanaged
         where TTo : unmanaged
-        => ref Unsafe.As<Vector<TFrom>[], Vector<TTo>[]>(ref Unsafe.AsRef(in x));
+    {
+        Guard.DebugValidArgument(
+            typeof(TFrom) == typeof(TTo),
+            $"Cannot reinterpret from {typeof(TFrom)} to {typeof(TTo)} because their sizes are different.");
+        unsafe
+        {
+            return Unsafe.As<Vector<TFrom>[], Vector<TTo>[]>(ref Unsafe.AsRef(in x));
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector<byte> AsUnsigned(in Vector<byte> v) => v;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector<ushort> AsUnsigned(in Vector<ushort> v) => v;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector<uint> AsUnsigned(in Vector<uint> v) => v;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector<ulong> AsUnsigned(in Vector<ulong> v) => v;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector<nuint> AsUnsigned(in Vector<nuint> v) => v;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector<byte> AsUnsigned(in Vector<sbyte> v)
+        => BitCast<Vector<sbyte>, Vector<byte>>(v);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector<ushort> AsUnsigned(in Vector<short> v)
+        => BitCast<Vector<short>, Vector<ushort>>(v);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector<uint> AsUnsigned(in Vector<int> v)
+        => BitCast<Vector<int>, Vector<uint>>(v);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector<ulong> AsUnsigned(in Vector<long> v)
+        => BitCast<Vector<long>, Vector<ulong>>(v);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Vector<nuint> AsUnsigned(in Vector<nint> v)
+        => BitCast<Vector<nint>, Vector<nuint>>(v);
 
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<byte> AsUnsigned(in Vector<byte> v) => ref v;
+    public static Vector<sbyte> AsSigned(in Vector<sbyte> v) => v;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<ushort> AsUnsigned(in Vector<ushort> v) => ref v;
+    public static Vector<short> AsSigned(in Vector<short> v) => v;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<uint> AsUnsigned(in Vector<uint> v) => ref v;
+    public static Vector<int> AsSigned(in Vector<int> v) => v;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<ulong> AsUnsigned(in Vector<ulong> v) => ref v;
+    public static Vector<long> AsSigned(in Vector<long> v) => v;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<nuint> AsUnsigned(in Vector<nuint> v) => ref v;
+    public static Vector<nint> AsSigned(in Vector<nint> v) => v;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<byte> AsUnsigned(in Vector<sbyte> v)
-        => ref Reinterpret<Vector<sbyte>, Vector<byte>>(v);
+    public static Vector<sbyte> AsSigned(in Vector<byte> v)
+        => BitCast<Vector<byte>, Vector<sbyte>>(v);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<ushort> AsUnsigned(in Vector<short> v)
-        => ref Reinterpret<Vector<short>, Vector<ushort>>(v);
+    public static Vector<short> AsSigned(in Vector<ushort> v)
+        => BitCast<Vector<ushort>, Vector<short>>(v);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<uint> AsUnsigned(in Vector<int> v)
-        => ref Reinterpret<Vector<int>, Vector<uint>>(v);
+    public static Vector<int> AsSigned(in Vector<uint> v)
+        => BitCast<Vector<uint>, Vector<int>>(v);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<ulong> AsUnsigned(in Vector<long> v)
-        => ref Reinterpret<Vector<long>, Vector<ulong>>(v);
+    public static Vector<long> AsSigned(in Vector<ulong> v)
+        => BitCast<Vector<ulong>, Vector<long>>(v);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<nuint> AsUnsigned(in Vector<nint> v)
-        => ref Reinterpret<Vector<nint>, Vector<nuint>>(v);
-
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<sbyte> AsSigned(in Vector<sbyte> v) => ref v;
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<short> AsSigned(in Vector<short> v) => ref v;
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<int> AsSigned(in Vector<int> v) => ref v;
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<long> AsSigned(in Vector<long> v) => ref v;
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<nint> AsSigned(in Vector<nint> v) => ref v;
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<sbyte> AsSigned(in Vector<byte> v)
-        => ref Reinterpret<Vector<byte>, Vector<sbyte>>(v);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<short> AsSigned(in Vector<ushort> v)
-        => ref Reinterpret<Vector<ushort>, Vector<short>>(v);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<int> AsSigned(in Vector<uint> v)
-        => ref Reinterpret<Vector<uint>, Vector<int>>(v);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<long> AsSigned(in Vector<ulong> v)
-        => ref Reinterpret<Vector<ulong>, Vector<long>>(v);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<nint> AsSigned(in Vector<nuint> v)
-        => ref Reinterpret<Vector<nuint>, Vector<nint>>(v);
+    public static Vector<nint> AsSigned(in Vector<nuint> v)
+        => BitCast<Vector<nuint>, Vector<nint>>(v);
 
 
 #if NETCOREAPP3_0_OR_GREATER
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<T> AsVector<T>(in Vector256<T> v)
+    public static Vector<T> AsVector<T>(Vector256<T> v)
         where T : unmanaged
-        => ref Reinterpret<Vector256<T>, Vector<T>>(v);
+        => BitCast<Vector256<T>, Vector<T>>(v);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector<T> AsVector<T>(in Vector128<T> v)
+    public static Vector<T> AsVector<T>(Vector128<T> v)
         where T : unmanaged
-        => ref Reinterpret<Vector128<T>, Vector<T>>(v);
+        => BitCast<Vector128<T>, Vector<T>>(v);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector256<T> AsVector256<T>(in Vector<T> v)
+    public static Vector256<T> AsVector256<T>(Vector<T> v)
         where T : unmanaged
-        => ref Reinterpret<Vector<T>, Vector256<T>>(v);
+        => BitCast<Vector<T>, Vector256<T>>(v);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ref readonly Vector128<T> AsVector128<T>(in Vector<T> v)
+    public static Vector128<T> AsVector128<T>(Vector<T> v)
         where T : unmanaged
-        => ref Reinterpret<Vector<T>, Vector128<T>>(v);
+        => BitCast<Vector<T>, Vector128<T>>(v);
 
 #endif
 }

--- a/src/SmartVectorDotNet/ScalarOp/ScalarOp._BitOperations.CountLeadingZeros.cs
+++ b/src/SmartVectorDotNet/ScalarOp/ScalarOp._BitOperations.CountLeadingZeros.cs
@@ -1,9 +1,7 @@
-using System.Runtime.CompilerServices;
 using GenericSpecialization;
 
 namespace SmartVectorDotNet;
 using H = InternalHelpers;
-
 
 partial class ScalarOp
 {
@@ -68,11 +66,11 @@ partial class ScalarOp
 
     /// <inheritdoc cref="CountLeadingZeros_default" />
     public static float CountLeadingZeros(float x)
-        => CountLeadingZeros(H.Reinterpret<float, uint>(x));
+        => CountLeadingZeros(H.BitCast<float, uint>(x));
 
     /// <inheritdoc cref="CountLeadingZeros_default" />
     public static double CountLeadingZeros(double x)
-        => CountLeadingZeros(H.Reinterpret<double, ulong>(x));
+        => CountLeadingZeros(H.BitCast<double, ulong>(x));
 
 #if NETCOREAPP3_0_OR_GREATER
 
@@ -112,11 +110,11 @@ partial class ScalarOp
 
     public static partial nuint CountLeadingZeros(nuint x)
     {
-        if (Unsafe.SizeOf<nuint>() == sizeof(uint))
+        if (H.SizeOf<nuint>() == sizeof(uint))
         {
             return CountLeadingZeros((uint)x);
         }
-        if (Unsafe.SizeOf<nuint>() == sizeof(ulong))
+        if (H.SizeOf<nuint>() == sizeof(ulong))
         {
             return (nuint)CountLeadingZeros((ulong)x);
         }

--- a/src/SmartVectorDotNet/ScalarOp/ScalarOp._BitOperations.CountPopulation.cs
+++ b/src/SmartVectorDotNet/ScalarOp/ScalarOp._BitOperations.CountPopulation.cs
@@ -57,11 +57,11 @@ partial class ScalarOp
 
     /// <inheritdoc cref="CountPopulation_default" />
     public static float CountPopulation(float x)
-        => CountPopulation(H.Reinterpret<float, uint>(x));
+        => CountPopulation(H.BitCast<float, uint>(x));
 
     /// <inheritdoc cref="CountPopulation_default" />
     public static double CountPopulation(double x)
-        => CountPopulation(H.Reinterpret<double, ulong>(x));
+        => CountPopulation(H.BitCast<double, ulong>(x));
 
 #if NETCOREAPP3_0_OR_GREATER
     public static partial byte CountPopulation(byte x)

--- a/src/SmartVectorDotNet/ScalarOp/ScalarOp._BitOperations.CountTrailingZeros.cs
+++ b/src/SmartVectorDotNet/ScalarOp/ScalarOp._BitOperations.CountTrailingZeros.cs
@@ -50,10 +50,10 @@ partial class ScalarOp
     public static nint CountTrailingZeros(nint x) => (nint)CountTrailingZeros((nuint)x);
 
     /// <inheritdoc cref="CountTrailingZeros_default" />
-    public static float CountTrailingZeros(float x) => CountTrailingZeros(H.Reinterpret<float, uint>(x));
+    public static float CountTrailingZeros(float x) => CountTrailingZeros(H.BitCast<float, uint>(x));
 
     /// <inheritdoc cref="CountTrailingZeros_default" />
-    public static double CountTrailingZeros(double x) => CountTrailingZeros(H.Reinterpret<double, ulong>(x));
+    public static double CountTrailingZeros(double x) => CountTrailingZeros(H.BitCast<double, ulong>(x));
 
 #if NETCOREAPP3_0_OR_GREATER
     public static partial byte CountTrailingZeros(byte x)
@@ -126,11 +126,11 @@ partial class ScalarOp
 
     public static partial nuint CountTrailingZeros(nuint x)
     {
-        if (Unsafe.SizeOf<nuint>() == sizeof(uint))
+        if (H.SizeOf<nuint>() == sizeof(uint))
         {
             return CountTrailingZeros((uint)x);
         }
-        if(Unsafe.SizeOf<nuint>() == sizeof(ulong))
+        if(H.SizeOf<nuint>() == sizeof(ulong))
         {
             return (nuint)CountTrailingZeros((ulong)x);
         }

--- a/src/SmartVectorDotNet/ScalarOp/ScalarOp._BitOperations.IEEE754Specific.cs
+++ b/src/SmartVectorDotNet/ScalarOp/ScalarOp._BitOperations.IEEE754Specific.cs
@@ -1,6 +1,7 @@
 namespace SmartVectorDotNet;
 
 using GenericSpecialization;
+using H = InternalHelpers;
 using static ScalarOp.Const;
 
 partial class ScalarOp
@@ -34,9 +35,9 @@ partial class ScalarOp
         /// </summary>
         public static readonly T MachineEpsilon
             = IsT<double>()
-                ? Reinterpret(Scale<double>(-DoubleExpBitOffset, 1))
+                ? H.BitCast<double, T>(Scale<double>(-DoubleExpBitOffset, 1))
             : IsT<float>()
-                ? Reinterpret(Scale<float>(-SingleExpBitOffset, 1))
+                ? H.BitCast<float, T>(Scale<float>(-SingleExpBitOffset, 1))
             : default;
 
         /// <summary>
@@ -44,9 +45,9 @@ partial class ScalarOp
         /// </summary>
         public static readonly T PositiveMinimumNormalizedNumber
             = IsT<double>()
-                ? Reinterpret(Scale<double>(1.0 - DoubleExpPartBias, 1))
+                ? H.BitCast<double, T>(Scale<double>(1.0 - DoubleExpPartBias, 1))
             : IsT<float>()
-                ? Reinterpret(Scale<float>(1.0f - SingleExpPartBias, 1))
+                ? H.BitCast<float, T>(Scale<float>(1.0f - SingleExpPartBias, 1))
             : default;
     }
 
@@ -96,7 +97,7 @@ partial class ScalarOp
     /// <param name="frac"></param>
     public static void Decompose(double x, out long sign, out long expo, out long frac)
     {
-        var bin = Reinterpret<double, long>(x);
+        var bin = H.BitCast<double, long>(x);
         sign = (bin & DoubleSignPartMask) >> DoubleSignBitOffset;
         expo = (bin & DoubleExpPartMask) >> DoubleExpBitOffset;
         frac = bin & DoubleFracPartMask;
@@ -111,7 +112,7 @@ partial class ScalarOp
     /// <param name="frac"></param>
     public static void Decompose(float x, out int sign, out int expo, out int frac)
     {
-        var bin = Reinterpret<float, int>(x);
+        var bin = H.BitCast<float, int>(x);
         sign = (bin & SingleSignPartMask) >> SingleSignBitOffset;
         expo = (bin & SingleExpPartMask) >> SingleExpBitOffset;
         frac = bin & SingleFracPartMask;
@@ -136,11 +137,11 @@ partial class ScalarOp
 
     /// <see cref="Scale_default" />
     public static double Scale(double n, double x)
-        => x * Reinterpret<long, double>(((long)n + DoubleExpPartBias) << DoubleExpBitOffset);
+        => x * H.BitCast<long, double>(((long)n + DoubleExpPartBias) << DoubleExpBitOffset);
 
     /// <see cref="Scale_default" />
     public static float Scale(float n, float x)
-        => x * Reinterpret<int, float>(((int)n + SingleExpPartBias) << SingleExpBitOffset);
+        => x * H.BitCast<int, float>(((int)n + SingleExpPartBias) << SingleExpBitOffset);
 
 
     /// <summary>
@@ -151,7 +152,7 @@ partial class ScalarOp
     /// <param name="frac"></param>
     /// <returns></returns>
     public static double Scale(long sign, long expo, long frac)
-        => Reinterpret<long, double>((sign << DoubleSignBitOffset) | (expo << DoubleExpBitOffset) | frac);
+        => H.BitCast<long, double>((sign << DoubleSignBitOffset) | (expo << DoubleExpBitOffset) | frac);
 
     /// <summary>
     /// Composes IEEE754 parts into one real number.
@@ -161,5 +162,5 @@ partial class ScalarOp
     /// <param name="frac"></param>
     /// <returns></returns>
     public static float Scale(int sign, int expo, int frac)
-        => Reinterpret<int, float>((sign << SingleSignBitOffset) | (expo << SingleExpBitOffset) | frac);
+        => H.BitCast<int, float>((sign << SingleSignBitOffset) | (expo << SingleExpBitOffset) | frac);
 }

--- a/src/SmartVectorDotNet/ScalarOp/ScalarOp._Const.cs
+++ b/src/SmartVectorDotNet/ScalarOp/ScalarOp._Const.cs
@@ -1,9 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
 using GenericSpecialization;
 
 namespace SmartVectorDotNet;
+using H = InternalHelpers;
 
 partial class ScalarOp
 {
@@ -127,8 +125,8 @@ partial class ScalarOp
             one = 1;
             minValue = float.MinValue;
             maxValue = float.MaxValue;
-            msb = Reinterpret<uint, float>(0x8000_0000);
-            lsb = Reinterpret<uint, float>(1);
+            msb = H.BitCast<uint, float>(0x8000_0000);
+            lsb = H.BitCast<uint, float>(1);
         }
         private static void GetConst(out double zero, out double one, out double minValue, out double maxValue, out double msb, out double lsb)
         {
@@ -136,8 +134,8 @@ partial class ScalarOp
             one = 1;
             minValue = double.MinValue;
             maxValue = double.MaxValue;
-            msb = Reinterpret<ulong, double>(0x8000_0000_0000_0000);
-            lsb = Reinterpret<ulong, double>(1);
+            msb = H.BitCast<ulong, double>(0x8000_0000_0000_0000);
+            lsb = H.BitCast<ulong, double>(1);
         }
 
         [PrimaryGeneric(nameof(GetPI_default))]
@@ -181,10 +179,6 @@ partial class ScalarOp
     {
         private static bool IsT<TEntity>()
             => typeof(T) == typeof(TEntity);
-
-        private static T Reinterpret<TFrom>(TFrom x)
-            where TFrom : unmanaged
-            => Reinterpret<TFrom, T>(x);
 
         /// <summary> Gets a value of <typeparamref name="T"/> which is corresponding to <c>0</c>. </summary>
         public static readonly T Zero;

--- a/src/SmartVectorDotNet/ScalarOp/ScalarOp._Convert.g.cs
+++ b/src/SmartVectorDotNet/ScalarOp/ScalarOp._Convert.g.cs
@@ -20,11 +20,13 @@ partial class ScalarOp
         where TFrom : unmanaged
         where TTo : unmanaged
     {
-        static ref readonly T to<T>(in TFrom x) => ref H.Reinterpret<TFrom, T>(in x);
-        static ref readonly TTo from<T>(in T x) => ref H.Reinterpret<T, TTo>(in x);
+        static T to<T>(TFrom x) where T : unmanaged => H.BitCast<TFrom, T>(x);
+        static TTo from<T>(T x) where T : unmanaged => H.BitCast<T, TTo>(x);
 
         if(typeof(TFrom) == typeof(TTo))
-            return Reinterpret<TFrom, TTo>(x);
+        {
+            return H.BitCast<TFrom, TTo>(x);
+        }
 
         if(typeof(TFrom) == typeof(byte  ))
         {

--- a/src/SmartVectorDotNet/ScalarOp/ScalarOp._Convert.tt
+++ b/src/SmartVectorDotNet/ScalarOp/ScalarOp._Convert.tt
@@ -42,11 +42,13 @@ partial class ScalarOp
         where TFrom : unmanaged
         where TTo : unmanaged
     {
-        static ref readonly T to<T>(in TFrom x) => ref H.Reinterpret<TFrom, T>(in x);
-        static ref readonly TTo from<T>(in T x) => ref H.Reinterpret<T, TTo>(in x);
+        static T to<T>(TFrom x) where T : unmanaged => H.BitCast<TFrom, T>(x);
+        static TTo from<T>(T x) where T : unmanaged => H.BitCast<T, TTo>(x);
 
         if(typeof(TFrom) == typeof(TTo))
-            return Reinterpret<TFrom, TTo>(x);
+        {
+            return H.BitCast<TFrom, TTo>(x);
+        }
 
 <#  foreach(var typeA in types) { #>
         if(typeof(TFrom) == typeof(<#=typeA#>))

--- a/src/SmartVectorDotNet/ScalarOp/ScalarOp._Operator.Binary.g.cs
+++ b/src/SmartVectorDotNet/ScalarOp/ScalarOp._Operator.Binary.g.cs
@@ -5,6 +5,7 @@ using System.CodeDom.Compiler;
 using System.Runtime.CompilerServices;
 using GenericSpecialization;
 namespace SmartVectorDotNet;
+using H = InternalHelpers;
 
 partial class ScalarOp
 {
@@ -347,12 +348,12 @@ partial class ScalarOp
     /** <inheritdoc cref="BitwiseOr_default" /> */
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static float BitwiseOr(float x, float y)
-        => Reinterpret<uint, float>(Reinterpret<float, uint>(x) | Reinterpret<float, uint>(y));
+        => H.BitCast<uint, float>(H.BitCast<float, uint>(x) | H.BitCast<float, uint>(y));
 
     /** <inheritdoc cref="BitwiseOr_default" /> */
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static double BitwiseOr(double x, double y)
-        => Reinterpret<ulong, double>(Reinterpret<double, ulong>(x) | Reinterpret<double, ulong>(y));
+        => H.BitCast<ulong, double>(H.BitCast<double, ulong>(x) | H.BitCast<double, ulong>(y));
 
     #endregion BitwiseOr
 
@@ -389,12 +390,12 @@ partial class ScalarOp
     /** <inheritdoc cref="BitwiseAnd_default" /> */
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static float BitwiseAnd(float x, float y)
-        => Reinterpret<uint, float>(Reinterpret<float, uint>(x) & Reinterpret<float, uint>(y));
+        => H.BitCast<uint, float>(H.BitCast<float, uint>(x) & H.BitCast<float, uint>(y));
 
     /** <inheritdoc cref="BitwiseAnd_default" /> */
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static double BitwiseAnd(double x, double y)
-        => Reinterpret<ulong, double>(Reinterpret<double, ulong>(x) & Reinterpret<double, ulong>(y));
+        => H.BitCast<ulong, double>(H.BitCast<double, ulong>(x) & H.BitCast<double, ulong>(y));
 
     #endregion BitwiseAnd
 
@@ -431,12 +432,12 @@ partial class ScalarOp
     /** <inheritdoc cref="BitwiseXor_default" /> */
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static float BitwiseXor(float x, float y)
-        => Reinterpret<uint, float>(Reinterpret<float, uint>(x) ^ Reinterpret<float, uint>(y));
+        => H.BitCast<uint, float>(H.BitCast<float, uint>(x) ^ H.BitCast<float, uint>(y));
 
     /** <inheritdoc cref="BitwiseXor_default" /> */
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static double BitwiseXor(double x, double y)
-        => Reinterpret<ulong, double>(Reinterpret<double, ulong>(x) ^ Reinterpret<double, ulong>(y));
+        => H.BitCast<ulong, double>(H.BitCast<double, ulong>(x) ^ H.BitCast<double, ulong>(y));
 
     #endregion BitwiseXor
 

--- a/src/SmartVectorDotNet/ScalarOp/ScalarOp._Operator.Binary.tt
+++ b/src/SmartVectorDotNet/ScalarOp/ScalarOp._Operator.Binary.tt
@@ -53,6 +53,7 @@ using System.CodeDom.Compiler;
 using System.Runtime.CompilerServices;
 using GenericSpecialization;
 namespace SmartVectorDotNet;
+using H = InternalHelpers;
 
 partial class ScalarOp
 {
@@ -127,12 +128,12 @@ public void GenerateSpecializations(string opname, string checkKeyword, bool isA
     /** <inheritdoc cref="<#=opname#>_default" /> */
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static float <#=opname#>(float x, float y)
-        => Reinterpret<uint, float>(<#=op($"Reinterpret<float, uint>(x)", $"Reinterpret<float, uint>(y)")#>);
+        => H.BitCast<uint, float>(<#=op($"H.BitCast<float, uint>(x)", $"H.BitCast<float, uint>(y)")#>);
 
     /** <inheritdoc cref="<#=opname#>_default" /> */
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static double <#=opname#>(double x, double y)
-        => Reinterpret<ulong, double>(<#=op($"Reinterpret<double, ulong>(x)", $"Reinterpret<double, ulong>(y)")#>);
+        => H.BitCast<ulong, double>(<#=op($"H.BitCast<double, ulong>(x)", $"H.BitCast<double, ulong>(y)")#>);
 <#+
     }
 }

--- a/src/SmartVectorDotNet/ScalarOp/ScalarOp._Operator.Shift.g.cs
+++ b/src/SmartVectorDotNet/ScalarOp/ScalarOp._Operator.Shift.g.cs
@@ -5,6 +5,7 @@ using System.CodeDom.Compiler;
 using System.Runtime.CompilerServices;
 using GenericSpecialization;
 namespace SmartVectorDotNet;
+using H = InternalHelpers;
 
 partial class ScalarOp
 {
@@ -37,11 +38,11 @@ partial class ScalarOp
 
     /** <inheritdoc cref="ShiftLeft_default" /> */
     public static float ShiftLeft(float x, int y)
-        => Reinterpret<int, float>(Reinterpret<float, int>(x) << y);
+        => H.BitCast<int, float>(H.BitCast<float, int>(x) << y);
 
     /** <inheritdoc cref="ShiftLeft_default" /> */
     public static double ShiftLeft(double x, int y)
-        => Reinterpret<long, double>(Reinterpret<double, long>(x) << y);
+        => H.BitCast<long, double>(H.BitCast<double, long>(x) << y);
 
     #endregion
 
@@ -74,11 +75,11 @@ partial class ScalarOp
 
     /** <inheritdoc cref="ShiftRight_default" /> */
     public static float ShiftRight(float x, int y)
-        => Reinterpret<int, float>(Reinterpret<float, int>(x) >> y);
+        => H.BitCast<int, float>(H.BitCast<float, int>(x) >> y);
 
     /** <inheritdoc cref="ShiftRight_default" /> */
     public static double ShiftRight(double x, int y)
-        => Reinterpret<long, double>(Reinterpret<double, long>(x) >> y);
+        => H.BitCast<long, double>(H.BitCast<double, long>(x) >> y);
 
     #endregion
 

--- a/src/SmartVectorDotNet/ScalarOp/ScalarOp._Operator.Shift.tt
+++ b/src/SmartVectorDotNet/ScalarOp/ScalarOp._Operator.Shift.tt
@@ -29,6 +29,7 @@ using System.CodeDom.Compiler;
 using System.Runtime.CompilerServices;
 using GenericSpecialization;
 namespace SmartVectorDotNet;
+using H = InternalHelpers;
 
 partial class ScalarOp
 {
@@ -55,11 +56,11 @@ partial class ScalarOp
 
     /** <inheritdoc cref="<#=opname#>_default" /> */
     public static float <#=opname#>(float x, int y)
-        => Reinterpret<int, float>(<#=op("Reinterpret<float, int>(x)", "y")#>);
+        => H.BitCast<int, float>(<#=op("H.BitCast<float, int>(x)", "y")#>);
 
     /** <inheritdoc cref="<#=opname#>_default" /> */
     public static double <#=opname#>(double x, int y)
-        => Reinterpret<long, double>(<#=op("Reinterpret<double, long>(x)", "y")#>);
+        => H.BitCast<long, double>(<#=op("H.BitCast<double, long>(x)", "y")#>);
 
     #endregion
 

--- a/src/SmartVectorDotNet/ScalarOp/ScalarOp._Operator.Unary.cs
+++ b/src/SmartVectorDotNet/ScalarOp/ScalarOp._Operator.Unary.cs
@@ -118,10 +118,10 @@ partial class ScalarOp
 
     /** <inheritdoc cref="Complement_default"/> */
     public static float  Complement(float x)
-        => Reinterpret<int, float>(~Reinterpret<float, int>(x));
+        => H.BitCast<int, float>(~H.BitCast<float, int>(x));
 
     /** <inheritdoc cref="Complement_default"/> */
     public static double Complement(double x)
-        => Reinterpret<long, double>(~Reinterpret<double, long>(x));
+        => H.BitCast<long, double>(~H.BitCast<double, long>(x));
 }
 #pragma warning restore format

--- a/src/SmartVectorDotNet/ScalarOp/ScalarOp.cs
+++ b/src/SmartVectorDotNet/ScalarOp/ScalarOp.cs
@@ -1,8 +1,4 @@
 #pragma warning disable IDE0130
-using System;
-using System.Numerics;
-using System.Runtime.CompilerServices;
-
 namespace SmartVectorDotNet;
 
 /// <summary>
@@ -10,10 +6,4 @@ namespace SmartVectorDotNet;
 /// </summary>
 public static partial class ScalarOp
 {
-    private const MethodImplOptions _inlining = MethodImplOptions.AggressiveInlining;
-
-    internal static TTo Reinterpret<TFrom, TTo>(in TFrom x)
-        where TFrom : unmanaged
-        where TTo : unmanaged
-        => Unsafe.As<TFrom, TTo>(ref Unsafe.AsRef(in x));
 }

--- a/src/SmartVectorDotNet/UnsafeApiAttribute.cs
+++ b/src/SmartVectorDotNet/UnsafeApiAttribute.cs
@@ -1,0 +1,9 @@
+namespace SmartVectorDotNet;
+
+/// <summary>
+/// Marks API to be required to make safe on caller side due to its memory insecurity.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = true)]
+internal sealed class UnsafeApiAttribute : Attribute
+{
+}

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._BitOperations.CountLeadingZeros.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._BitOperations.CountLeadingZeros.cs
@@ -66,38 +66,38 @@ partial class VectorOp
     /// <inheritdoc cref="CountLeadingZeros_default" />
     public static Vector<nuint> CountLeadingZeros(Vector<nuint> x)
     {
-        if (Unsafe.SizeOf<nuint>() == sizeof(ulong)) { return H.Reinterpret<ulong, nuint>(CountLeadingZeros(H.Reinterpret<nuint, ulong>(x))); }
-        if (Unsafe.SizeOf<nuint>() == sizeof(uint)) { return H.Reinterpret<uint, nuint>(CountLeadingZeros(H.Reinterpret<nuint, uint>(x))); }
+        if (H.SizeOf<nuint>() == sizeof(ulong)) { return H.BitCastV<ulong, nuint>(CountLeadingZeros(H.BitCastV<nuint, ulong>(x))); }
+        if (H.SizeOf<nuint>() == sizeof(uint)) { return H.BitCastV<uint, nuint>(CountLeadingZeros(H.BitCastV<nuint, uint>(x))); }
         throw new NotSupportedException();
     }
 
     /// <inheritdoc cref="CountLeadingZeros_default" />
     public static Vector<sbyte> CountLeadingZeros(Vector<sbyte> x)
-        => H.Reinterpret<byte, sbyte>(CountLeadingZeros(H.Reinterpret<sbyte, byte>(x)));
+        => H.BitCastV<byte, sbyte>(CountLeadingZeros(H.BitCastV<sbyte, byte>(x)));
 
     /// <inheritdoc cref="CountLeadingZeros_default" />
     public static Vector<short> CountLeadingZeros(Vector<short> x)
-        => H.Reinterpret<ushort, short>(CountLeadingZeros(H.Reinterpret<short, ushort>(x)));
+        => H.BitCastV<ushort, short>(CountLeadingZeros(H.BitCastV<short, ushort>(x)));
 
     /// <inheritdoc cref="CountLeadingZeros_default" />
     public static Vector<int> CountLeadingZeros(Vector<int> x)
-        => H.Reinterpret<uint, int>(CountLeadingZeros(H.Reinterpret<int, uint>(x)));
+        => H.BitCastV<uint, int>(CountLeadingZeros(H.BitCastV<int, uint>(x)));
 
     /// <inheritdoc cref="CountLeadingZeros_default" />
     public static Vector<long> CountLeadingZeros(Vector<long> x)
-        => H.Reinterpret<ulong, long>(CountLeadingZeros(H.Reinterpret<long, ulong>(x)));
+        => H.BitCastV<ulong, long>(CountLeadingZeros(H.BitCastV<long, ulong>(x)));
 
     /// <inheritdoc cref="CountLeadingZeros_default" />
     public static Vector<nint> CountLeadingZeros(Vector<nint> x)
-        => H.Reinterpret<nuint, nint>(CountLeadingZeros(H.Reinterpret<nint, nuint>(x)));
+        => H.BitCastV<nuint, nint>(CountLeadingZeros(H.BitCastV<nint, nuint>(x)));
 
     /// <inheritdoc cref="CountLeadingZeros_default" />
     public static Vector<float> CountLeadingZeros(Vector<float> x)
-        => Vector.ConvertToSingle(CountLeadingZeros(H.Reinterpret<float, uint>(x)));
+        => Vector.ConvertToSingle(CountLeadingZeros(H.BitCastV<float, uint>(x)));
 
     /// <inheritdoc cref="CountLeadingZeros_default" />
     public static Vector<double> CountLeadingZeros(Vector<double> x)
-        => Vector.ConvertToDouble(CountLeadingZeros(H.Reinterpret<double, ulong>(x)));
+        => Vector.ConvertToDouble(CountLeadingZeros(H.BitCastV<double, ulong>(x)));
 
 #pragma warning restore format
 }

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._BitOperations.CountPopulation.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._BitOperations.CountPopulation.cs
@@ -114,38 +114,38 @@ partial class VectorOp
     /** <inheritdoc cref="CountPopulation_default" /> */
     public static Vector<nuint> CountPopulation(Vector<nuint> x)
     {
-        if (Unsafe.SizeOf<nuint>() == sizeof(ulong)) { return H.Reinterpret<ulong, nuint>(CountPopulation(H.Reinterpret<nuint, ulong>(x))); }
-        if (Unsafe.SizeOf<nuint>() == sizeof(uint )) { return H.Reinterpret<uint , nuint>(CountPopulation(H.Reinterpret<nuint, uint >(x))); }
+        if (H.SizeOf<nuint>() == sizeof(ulong)) { return H.BitCastV<ulong, nuint>(CountPopulation(H.BitCastV<nuint, ulong>(x))); }
+        if (H.SizeOf<nuint>() == sizeof(uint )) { return H.BitCastV<uint , nuint>(CountPopulation(H.BitCastV<nuint, uint >(x))); }
         throw new NotSupportedException();
     }
 
     /** <inheritdoc cref="CountPopulation_default" /> */
     public static Vector<sbyte> CountPopulation(Vector<sbyte> x)
-        => H.Reinterpret<byte, sbyte>(CountPopulation(H.Reinterpret<sbyte, byte>(x)));
+        => H.BitCastV<byte, sbyte>(CountPopulation(H.BitCastV<sbyte, byte>(x)));
 
     /** <inheritdoc cref="CountPopulation_default" /> */
     public static Vector<short> CountPopulation(Vector<short> x)
-        => H.Reinterpret<ushort, short>(CountPopulation(H.Reinterpret<short, ushort>(x)));
+        => H.BitCastV<ushort, short>(CountPopulation(H.BitCastV<short, ushort>(x)));
 
     /** <inheritdoc cref="CountPopulation_default" /> */
     public static Vector<int> CountPopulation(Vector<int> x)
-        => H.Reinterpret<uint, int>(CountPopulation(H.Reinterpret<int, uint>(x)));
+        => H.BitCastV<uint, int>(CountPopulation(H.BitCastV<int, uint>(x)));
 
     /** <inheritdoc cref="CountPopulation_default" /> */
     public static Vector<long> CountPopulation(Vector<long> x)
-        => H.Reinterpret<ulong, long>(CountPopulation(H.Reinterpret<long, ulong>(x)));
+        => H.BitCastV<ulong, long>(CountPopulation(H.BitCastV<long, ulong>(x)));
 
     /** <inheritdoc cref="CountPopulation_default" /> */
     public static Vector<nint> CountPopulation(Vector<nint> x)
-        => H.Reinterpret<nuint, nint>(CountPopulation(H.Reinterpret<nint, nuint>(x)));
+        => H.BitCastV<nuint, nint>(CountPopulation(H.BitCastV<nint, nuint>(x)));
 
     /** <inheritdoc cref="CountPopulation_default" /> */
     public static Vector<float> CountPopulation(Vector<float> x)
-        => Vector.ConvertToSingle(CountPopulation(H.Reinterpret<float, uint>(x)));
+        => Vector.ConvertToSingle(CountPopulation(H.BitCastV<float, uint>(x)));
 
     /** <inheritdoc cref="CountPopulation_default" /> */
     public static Vector<double> CountPopulation(Vector<double> x)
-        => Vector.ConvertToDouble(CountPopulation(H.Reinterpret<double, ulong>(x)));
+        => Vector.ConvertToDouble(CountPopulation(H.BitCastV<double, ulong>(x)));
 
 
 #pragma warning restore format

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._BitOperations.CountTrailingZeros.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._BitOperations.CountTrailingZeros.cs
@@ -41,31 +41,31 @@ partial class VectorOp
 
     /** <inheritdoc cref="CountTrailingZeros_default" /> */
     public static Vector<sbyte> CountTrailingZeros(Vector<sbyte> x)
-        => H.Reinterpret<byte, sbyte>(CountTrailingZeros(H.Reinterpret<sbyte, byte>(x)));
+        => H.BitCastV<byte, sbyte>(CountTrailingZeros(H.BitCastV<sbyte, byte>(x)));
 
     /** <inheritdoc cref="CountTrailingZeros_default" /> */
     public static Vector<short> CountTrailingZeros(Vector<short> x)
-        => H.Reinterpret<ushort, short>(CountTrailingZeros(H.Reinterpret<short, ushort>(x)));
+        => H.BitCastV<ushort, short>(CountTrailingZeros(H.BitCastV<short, ushort>(x)));
 
     /** <inheritdoc cref="CountTrailingZeros_default" /> */
     public static Vector<int> CountTrailingZeros(Vector<int> x)
-        => H.Reinterpret<uint, int>(CountTrailingZeros(H.Reinterpret<int, uint>(x)));
+        => H.BitCastV<uint, int>(CountTrailingZeros(H.BitCastV<int, uint>(x)));
 
     /** <inheritdoc cref="CountTrailingZeros_default" /> */
     public static Vector<long> CountTrailingZeros(Vector<long> x)
-        => H.Reinterpret<ulong, long>(CountTrailingZeros(H.Reinterpret<long, ulong>(x)));
+        => H.BitCastV<ulong, long>(CountTrailingZeros(H.BitCastV<long, ulong>(x)));
 
     /** <inheritdoc cref="CountTrailingZeros_default" /> */
     public static Vector<nint> CountTrailingZeros(Vector<nint> x)
-        => H.Reinterpret<nuint, nint>(CountTrailingZeros(H.Reinterpret<nint, nuint>(x)));
+        => H.BitCastV<nuint, nint>(CountTrailingZeros(H.BitCastV<nint, nuint>(x)));
 
     /** <inheritdoc cref="CountTrailingZeros_default" /> */
     public static Vector<float> CountTrailingZeros(Vector<float> x)
-        => Vector.ConvertToSingle(CountTrailingZeros(H.Reinterpret<float, uint>(x)));
+        => Vector.ConvertToSingle(CountTrailingZeros(H.BitCastV<float, uint>(x)));
 
     /** <inheritdoc cref="CountTrailingZeros_default" /> */
     public static Vector<double> CountTrailingZeros(Vector<double> x)
-        => Vector.ConvertToDouble(CountTrailingZeros(H.Reinterpret<double, ulong>(x)));
+        => Vector.ConvertToDouble(CountTrailingZeros(H.BitCastV<double, ulong>(x)));
 
 #pragma warning restore format
 }

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._BitOperations.IEEE754Specific.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._BitOperations.IEEE754Specific.cs
@@ -51,16 +51,16 @@ partial class VectorOp
     {
         if (typeof(T) == typeof(double))
         {
-            Decompose(H.Reinterpret<T, double>(x), out Vector<long> nn, out Vector<double> aa);
-            n = H.Reinterpret<double, T>(Vector.ConvertToDouble(nn));
-            a = H.Reinterpret<double, T>(aa);
+            Decompose(H.BitCastV<T, double>(x), out Vector<long> nn, out Vector<double> aa);
+            n = H.BitCastV<double, T>(Vector.ConvertToDouble(nn));
+            a = H.BitCastV<double, T>(aa);
             return;
         }
         if (typeof(T) == typeof(float))
         {
-            Decompose(H.Reinterpret<T, float>(x), out Vector<int> nn, out Vector<float> aa);
-            n = H.Reinterpret<float, T>(Vector.ConvertToSingle(nn));
-            a = H.Reinterpret<float, T>(aa);
+            Decompose(H.BitCastV<T, float>(x), out Vector<int> nn, out Vector<float> aa);
+            n = H.BitCastV<float, T>(Vector.ConvertToSingle(nn));
+            a = H.BitCastV<float, T>(aa);
             return;
         }
         throw new NotSupportedException();
@@ -75,7 +75,7 @@ partial class VectorOp
     /// <param name="frac"></param>
     public static void Decompose(Vector<double> x, out Vector<long> sign, out Vector<long> expo, out Vector<long> frac)
     {
-        var bin = H.Reinterpret<double, long>(x);
+        var bin = H.BitCastV<double, long>(x);
         sign = ShiftRightLogical(
             BitwiseAnd(bin, IEEE754Double_.SignPartMask),
             SC.DoubleSignBitOffset);
@@ -109,7 +109,7 @@ partial class VectorOp
     /// <param name="frac"></param>
     public static void Decompose(Vector<float> x, out Vector<int> sign, out Vector<int> expo, out Vector<int> frac)
     {
-        var bin = H.Reinterpret<float, int>(x);
+        var bin = H.BitCastV<float, int>(x);
         sign = ShiftRightLogical(
             BitwiseAnd(bin, IEEE754Single_.SignPartMask),
             SC.SingleSignBitOffset);
@@ -181,7 +181,7 @@ partial class VectorOp
     /// <param name="frac"></param>
     /// <returns></returns>
     public static Vector<double> Scale(Vector<long> sign, Vector<long> expo, Vector<long> frac)
-        => H.Reinterpret<long, double>(ShiftLeft(sign, SC.DoubleSignBitOffset) | ShiftLeft(expo, SC.DoubleExpBitOffset) | frac);
+        => H.BitCastV<long, double>(ShiftLeft(sign, SC.DoubleSignBitOffset) | ShiftLeft(expo, SC.DoubleExpBitOffset) | frac);
 
 
     /// <summary>
@@ -192,7 +192,7 @@ partial class VectorOp
     /// <param name="frac"></param>
     /// <returns></returns>
     public static Vector<float> Scale(Vector<int> sign, Vector<int> expo, Vector<int> frac)
-        => H.Reinterpret<int, float>(ShiftLeft(sign, SC.SingleSignBitOffset) | ShiftLeft(expo, SC.SingleExpBitOffset) | frac);
+        => H.BitCastV<int, float>(ShiftLeft(sign, SC.SingleSignBitOffset) | ShiftLeft(expo, SC.SingleExpBitOffset) | frac);
 
     #endregion
 
@@ -209,21 +209,21 @@ partial class VectorOp
     {
         if(typeof(T) == typeof(double))
         {
-            var xx = H.Reinterpret<T, double>(x);
+            var xx = H.BitCastV<T, double>(x);
             Decompose(xx, out _, out var exp, out _);
             var retval = Vector.BitwiseAnd(
                 Vector.GreaterThan(exp, IEEE754Double_.IntZero),
                 Vector.LessThan(exp, IEEE754Double_.NRange));
-            return H.Reinterpret<long, T>(retval);
+            return H.BitCastV<long, T>(retval);
         }
         if (typeof(T) == typeof(float))
         {
-            var xx = H.Reinterpret<T, float>(x);
+            var xx = H.BitCastV<T, float>(x);
             Decompose(xx, out _, out var exp, out _);
             var retval = Vector.BitwiseAnd(
                 Vector.GreaterThan(exp, IEEE754Single_.IntZero),
                 Vector.LessThan(exp, IEEE754Single_.NRange));
-            return H.Reinterpret<int, T>(retval);
+            return H.BitCastV<int, T>(retval);
         }
         return default;
     }
@@ -243,21 +243,21 @@ partial class VectorOp
     {
         if (typeof(T) == typeof(double))
         {
-            var xx = H.Reinterpret<T, double>(x);
+            var xx = H.BitCastV<T, double>(x);
             Decompose(xx, out _, out var exp, out var frac);
             var retval = Vector.BitwiseAnd(
                 Vector.Equals(exp, IEEE754Double_.IntZero),
                 Vector.OnesComplement(Vector.Equals(frac, IEEE754Double_.IntZero)));
-            return H.Reinterpret<long, T>(retval);
+            return H.BitCastV<long, T>(retval);
         }
         if (typeof(T) == typeof(float))
         {
-            var xx = H.Reinterpret<T, float>(x);
+            var xx = H.BitCastV<T, float>(x);
             Decompose(xx, out _, out Vector<int> exp, out var frac);
             var retval = Vector.BitwiseAnd(
                 Vector.Equals(exp, IEEE754Single_.IntZero),
                 Vector.OnesComplement(Vector.Equals(frac, IEEE754Single_.IntZero)));
-            return H.Reinterpret<int, T>(retval);
+            return H.BitCastV<int, T>(retval);
         }
         return default;
     }
@@ -277,13 +277,13 @@ partial class VectorOp
     {
         if (typeof(T) == typeof(double))
         {
-            var xx = H.Reinterpret<T, double>(x);
-            return H.Reinterpret<long, T>(IsInfinity(xx));
+            var xx = H.BitCastV<T, double>(x);
+            return H.BitCastV<long, T>(IsInfinity(xx));
         }
         if (typeof(T) == typeof(float))
         {
-            var xx = H.Reinterpret<T, float>(x);
-            return H.Reinterpret<int, T>(IsInfinity(xx));
+            var xx = H.BitCastV<T, float>(x);
+            return H.BitCastV<int, T>(IsInfinity(xx));
         }
         return default;
     }
@@ -329,13 +329,13 @@ partial class VectorOp
     {
         if (typeof(T) == typeof(double))
         {
-            var xx = H.Reinterpret<T, double>(x);
-            return H.Reinterpret<long, T>(IsPositiveInfinity(xx));
+            var xx = H.BitCastV<T, double>(x);
+            return H.BitCastV<long, T>(IsPositiveInfinity(xx));
         }
         if (typeof(T) == typeof(float))
         {
-            var xx = H.Reinterpret<T, float>(x);
-            return H.Reinterpret<int, T>(IsPositiveInfinity(xx));
+            var xx = H.BitCastV<T, float>(x);
+            return H.BitCastV<int, T>(IsPositiveInfinity(xx));
         }
         return default;
     }
@@ -389,13 +389,13 @@ partial class VectorOp
     {
         if (typeof(T) == typeof(double))
         {
-            var xx = H.Reinterpret<T, double>(x);
-            return H.Reinterpret<long, T>(IsNegativeInfinity(xx));
+            var xx = H.BitCastV<T, double>(x);
+            return H.BitCastV<long, T>(IsNegativeInfinity(xx));
         }
         if (typeof(T) == typeof(float))
         {
-            var xx = H.Reinterpret<T, float>(x);
-            return H.Reinterpret<int, T>(IsNegativeInfinity(xx));
+            var xx = H.BitCastV<T, float>(x);
+            return H.BitCastV<int, T>(IsNegativeInfinity(xx));
         }
         return default;
     }
@@ -449,13 +449,13 @@ partial class VectorOp
     {
         if (typeof(T) == typeof(double))
         {
-            var xx = H.Reinterpret<T, double>(x);
-            return H.Reinterpret<long, T>(IsNaN(xx));
+            var xx = H.BitCastV<T, double>(x);
+            return H.BitCastV<long, T>(IsNaN(xx));
         }
         if (typeof(T) == typeof(float))
         {
-            var xx = H.Reinterpret<T, float>(x);
-            return H.Reinterpret<int, T>(IsNaN(xx));
+            var xx = H.BitCastV<T, float>(x);
+            return H.BitCastV<int, T>(IsNaN(xx));
         }
         return default;
     }

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._Const.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._Const.cs
@@ -32,7 +32,7 @@ partial class VectorOp
 
         private protected static Vector<T> As<TFrom>(Vector<TFrom> x)
             where TFrom : unmanaged
-            => H.Reinterpret<TFrom, T>(x);
+            => H.BitCastV<TFrom, T>(x);
 
         /// <summary> Gets the vector which has <c>0</c> values. </summary>
         public static readonly Vector<T> Zero = new(ScalarOp.Const<T>.Zero);

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._Convert.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._Convert.cs
@@ -1,22 +1,11 @@
 using System.Runtime.CompilerServices;
 
 namespace SmartVectorDotNet;
+using H = InternalHelpers;
 using NVector = System.Numerics.Vector;
 
 partial class VectorOp
 {
-    /** <summary> Operates As. </summary> **/
-    [MethodImpl(_inlining)]
-    public static Vector<TTo> As<TFrom, TTo>(Vector<TFrom> vector)
-        where TFrom : unmanaged
-        where TTo : unmanaged
-#if NET6_0_OR_GREATER
-        => NVector.As<TFrom, TTo>(vector);
-#else
-        => Unsafe.As<Vector<TFrom>, Vector<TTo>>(ref Unsafe.AsRef(vector));
-#endif
-
-
     /** <summary> Operates AsVectorByte. </summary> **/
     [MethodImpl(_inlining)]
     public static Vector<byte> AsVectorByte<T>(Vector<T> value)
@@ -59,7 +48,7 @@ partial class VectorOp
 #if NET6_0_OR_GREATER
         => NVector.AsVectorNInt(value);
 #else
-        => Unsafe.As<Vector<T>, Vector<nint>>(ref Unsafe.AsRef(value));
+        => H.BitCastV<T, nint>(value);
 #endif
 
 
@@ -70,7 +59,7 @@ partial class VectorOp
 #if NET6_0_OR_GREATER
         => NVector.AsVectorNUInt(value);
 #else
-        => Unsafe.As<Vector<T>, Vector<nuint>>(ref Unsafe.AsRef(value));
+        => H.BitCastV<T, nuint>(value);
 #endif
 
 

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._Math.Asinh.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._Math.Asinh.cs
@@ -7,9 +7,9 @@ file class Asinh_<T> : VectorOp.Const<T> where T : unmanaged
 {
     public static readonly Vector<T> Border =
         typeof(T) == typeof(double)
-            ? H.Reinterpret<double, T>(new Vector<double>(1.35e+7))
+            ? H.BitCastV<double, T>(new Vector<double>(1.35e+7))
         : typeof(T) == typeof(float)
-            ? H.Reinterpret<float, T>(new Vector<float>(1.35e+7f))
+            ? H.BitCastV<float, T>(new Vector<float>(1.35e+7f))
             : throw new ArgumentException();
 }
 

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._Math.Exp.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._Math.Exp.cs
@@ -6,8 +6,8 @@ using H = InternalHelpers;
 
 file class Exp_<T> : VectorOp.Const<T> where T : unmanaged
 {
-    internal static readonly Vector<T> Max = AsVector(ScalarOp.Log(double.MaxValue));
-    internal static readonly Vector<T> Min = AsVector(ScalarOp.Log(1 / double.MaxValue));
+    internal static readonly Vector<T> _max = AsVector(ScalarOp.Log(double.MaxValue));
+    internal static readonly Vector<T> _min = AsVector(ScalarOp.Log(1 / double.MaxValue));
 
     internal static ReadOnlySpan<Vector<T>> Coeffs => _expCoeffs;
     private static readonly Vector<T>[] _expCoeffs;
@@ -16,26 +16,26 @@ file class Exp_<T> : VectorOp.Const<T> where T : unmanaged
     {
         if (IsT<double>())
         {
-            Max = H.Reinterpret<double, T>(new Vector<double>(ScalarOp.Log(double.MaxValue)));
-            Min = H.Reinterpret<double, T>(new Vector<double>(ScalarOp.Log(1 / double.MaxValue)));
+            _max = H.BitCastV<double, T>(new Vector<double>(ScalarOp.Log(double.MaxValue)));
+            _min = H.BitCastV<double, T>(new Vector<double>(ScalarOp.Log(1 / double.MaxValue)));
             var expCoeffs = new Vector<double>[11];
             for (var i = 1; i <= 11; ++i)
             {
                 expCoeffs[i - 1] = new Vector<double>(1 / (double)i);
             }
-            _expCoeffs = H.Reinterpret<Vector<double>[], Vector<T>[]>(expCoeffs);
+            _expCoeffs = H.ReinterpretVArray<double, T>(expCoeffs);
         }
         else if (IsT<float>())
         {
-            Max = H.Reinterpret<float, T>(new Vector<float>(ScalarOp.Log(float.MaxValue)));
-            Min = H.Reinterpret<float, T>(new Vector<float>(ScalarOp.Log(1 / float.MaxValue)));
+            _max = H.BitCastV<float, T>(new Vector<float>(ScalarOp.Log(float.MaxValue)));
+            _min = H.BitCastV<float, T>(new Vector<float>(ScalarOp.Log(1 / float.MaxValue)));
 
             var expCoeffs = new Vector<float>[6];
             for (var i = 1; i <= 6; ++i)
             {
                 expCoeffs[i - 1] = new Vector<float>(1 / (float)i);
             }
-            _expCoeffs = H.Reinterpret<Vector<float>[], Vector<T>[]>(expCoeffs);
+            _expCoeffs = H.ReinterpretVArray<float, T>(expCoeffs);
         }
         else
         {
@@ -53,8 +53,8 @@ partial class VectorOp
     {
         Guard.OnlyRealSupported<T>();
 
-        var isSaturatedMax = GreaterThan(x, Exp_<T>.Max);
-        var isSaturatedMin = LessThan(x, Exp_<T>.Min);
+        var isSaturatedMax = GreaterThan(x, Exp_<T>._max);
+        var isSaturatedMin = LessThan(x, Exp_<T>._min);
         var isNormal = OnesComplement(BitwiseOr(isSaturatedMax, isSaturatedMin));
 
         return ConditionalSelect(
@@ -102,14 +102,14 @@ partial class VectorOp
         var n = Round(y);
         var a = y - n;
         var b = a * Exp_<float>.Log_E_2;
-        var z = Exp_<float>._0;                                         // a_7~
+        var z = Exp_<float>._0;                                      // a_7~
         z = (b * Exp_<float>.Coeffs[6 - 1]) * (Exp_<float>._1 + z);  // a_6
         z = (b * Exp_<float>.Coeffs[5 - 1]) * (Exp_<float>._1 + z);  // a_5
         z = (b * Exp_<float>.Coeffs[4 - 1]) * (Exp_<float>._1 + z);  // a_4
         z = (b * Exp_<float>.Coeffs[3 - 1]) * (Exp_<float>._1 + z);  // a_3
         z = (b * Exp_<float>.Coeffs[2 - 1]) * (Exp_<float>._1 + z);  // a_2
         z = (b * Exp_<float>.Coeffs[1 - 1]) * (Exp_<float>._1 + z);  // a_1
-        z = z + Exp_<float>._1;                                         // a_0
+        z = z + Exp_<float>._1;                                      // a_0
         return Scale(n, z);
     }
 #pragma warning restore format

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._Math.FusedMultiplyAdd.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._Math.FusedMultiplyAdd.cs
@@ -5,9 +5,7 @@ using System.Runtime.Intrinsics.X86;
 #endif
 
 namespace SmartVectorDotNet;
-
 using H = InternalHelpers;
-
 
 partial class VectorOp
 {
@@ -25,52 +23,52 @@ partial class VectorOp
 #if NET6_0_OR_GREATER
         if (Fma.IsSupported)
         {
-            if (Unsafe.SizeOf<Vector<T>>() == Unsafe.SizeOf<Vector256<T>>())
+            if (H.SizeOf<Vector<T>>() == H.SizeOf<Vector256<T>>())
             {
                 if (typeof(T) == typeof(double))
                 {
-                    return H.Reinterpret<double, T>(
+                    return H.BitCastV<double, T>(
                         Vector256.AsVector(
                             Fma.MultiplyAdd(
-                                H.Reinterpret<T, double>(x).AsVector256(),
-                                H.Reinterpret<T, double>(y).AsVector256(),
-                                H.Reinterpret<T, double>(z).AsVector256())
+                                H.BitCastV<T, double>(x).AsVector256(),
+                                H.BitCastV<T, double>(y).AsVector256(),
+                                H.BitCastV<T, double>(z).AsVector256())
                             )
                         );
                 }
                 if (typeof(T) == typeof(float))
                 {
-                    return H.Reinterpret<float, T>(
+                    return H.BitCastV<float, T>(
                         Vector256.AsVector(
                             Fma.MultiplyAdd(
-                                H.Reinterpret<T, float>(x).AsVector256(),
-                                H.Reinterpret<T, float>(y).AsVector256(),
-                                H.Reinterpret<T, float>(z).AsVector256())
+                                H.BitCastV<T, float>(x).AsVector256(),
+                                H.BitCastV<T, float>(y).AsVector256(),
+                                H.BitCastV<T, float>(z).AsVector256())
                             )
                         );
                 }
             }
-            if (Unsafe.SizeOf<Vector<T>>() == Unsafe.SizeOf<Vector128<T>>())
+            if (H.SizeOf<Vector<T>>() == H.SizeOf<Vector128<T>>())
             {
                 if (typeof(T) == typeof(double))
                 {
-                    return H.Reinterpret<double, T>(
+                    return H.BitCastV<double, T>(
                         Vector128.AsVector(
                             Fma.MultiplyAdd(
-                                H.Reinterpret<T, double>(x).AsVector128(),
-                                H.Reinterpret<T, double>(y).AsVector128(),
-                                H.Reinterpret<T, double>(z).AsVector128())
+                                H.BitCastV<T, double>(x).AsVector128(),
+                                H.BitCastV<T, double>(y).AsVector128(),
+                                H.BitCastV<T, double>(z).AsVector128())
                             )
                         );
                 }
                 if (typeof(T) == typeof(float))
                 {
-                    return H.Reinterpret<float, T>(
+                    return H.BitCastV<float, T>(
                         Vector128.AsVector(
                             Fma.MultiplyAdd(
-                                H.Reinterpret<T, float>(x).AsVector128(),
-                                H.Reinterpret<T, float>(y).AsVector128(),
-                                H.Reinterpret<T, float>(z).AsVector128())
+                                H.BitCastV<T, float>(x).AsVector128(),
+                                H.BitCastV<T, float>(y).AsVector128(),
+                                H.BitCastV<T, float>(z).AsVector128())
                             )
                         );
                 }

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._Math.Log.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._Math.Log.cs
@@ -17,7 +17,7 @@ file class Log_<T> : VectorOp.Const<T> where T : unmanaged
             {
                 logCoeffs[i] = new(ScalarOp.Pow(-1.0, i) / (i + 1.0));
             }
-            return H.Reinterpret<Vector<double>[], Vector<T>[]>(logCoeffs);
+            return H.ReinterpretVArray<double, T>(logCoeffs);
         }
         if (IsT<float>())
         {
@@ -26,7 +26,7 @@ file class Log_<T> : VectorOp.Const<T> where T : unmanaged
             {
                 logCoeffs[i] = new(ScalarOp.Pow(-1.0f, i) / (i + 1.0f));
             }
-            return H.Reinterpret<Vector<float>[], Vector<T>[]>(logCoeffs);
+            return H.ReinterpretVArray<float, T>(logCoeffs);
         }
         return default!;
     }

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._Math.Round.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._Math.Round.cs
@@ -7,7 +7,7 @@ using System.Runtime.Intrinsics.X86;
 using GenericSpecialization;
 
 namespace SmartVectorDotNet;
-
+using H = InternalHelpers;
 
 partial class VectorOp
 {
@@ -36,12 +36,12 @@ partial class VectorOp
     private static Vector<double> Round(Vector<double> x)
     {
 #if NET6_0_OR_GREATER
-        if (Unsafe.SizeOf<Vector<double>>() == Unsafe.SizeOf<Vector256<double>>() && Avx.IsSupported)
+        if (H.SizeOf<Vector<double>>() == H.SizeOf<Vector256<double>>() && Avx.IsSupported)
         {
             var xx = Vector256.AsVector256(x);
             return Avx.RoundToNearestInteger(xx).AsVector();
         }
-        if (Unsafe.SizeOf<Vector<double>>() == Unsafe.SizeOf<Vector128<double>>() && Sse41.IsSupported)
+        if (H.SizeOf<Vector<double>>() == H.SizeOf<Vector128<double>>() && Sse41.IsSupported)
         {
             var xx = Vector128.AsVector128(x);
             return Sse41.RoundToNearestInteger(xx).AsVector();
@@ -54,12 +54,12 @@ partial class VectorOp
     private static Vector<float> Round(Vector<float> x)
     {
 #if NET6_0_OR_GREATER
-        if (Unsafe.SizeOf<Vector<float>>() == Unsafe.SizeOf<Vector256<float>>() && Avx.IsSupported)
+        if (H.SizeOf<Vector<float>>() == H.SizeOf<Vector256<float>>() && Avx.IsSupported)
         {
             var xx = Vector256.AsVector256(x);
             return Avx.RoundToNearestInteger(xx).AsVector();
         }
-        if (Unsafe.SizeOf<Vector<float>>() == Unsafe.SizeOf<Vector128<float>>() && Sse41.IsSupported)
+        if (H.SizeOf<Vector<float>>() == H.SizeOf<Vector128<float>>() && Sse41.IsSupported)
         {
             var xx = Vector128.AsVector128(x);
             return Sse41.RoundToNearestInteger(xx).AsVector();

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._Math.Sign.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._Math.Sign.cs
@@ -1,4 +1,3 @@
-using System.Runtime.CompilerServices;
 namespace SmartVectorDotNet;
 using H = InternalHelpers;
 
@@ -47,9 +46,9 @@ partial class VectorOp
     {
         static Vector<T> core<S>(Vector<T> x)
             where S : unmanaged
-            => H.Reinterpret<S, T>(Equals(BitwiseAnd(Sign_<S>.SignBit, H.Reinterpret<T, S>(x)), Sign_<S>._0));
+            => H.BitCastV<S, T>(Equals(BitwiseAnd(Sign_<S>.SignBit, H.BitCastV<T, S>(x)), Sign_<S>._0));
 
-        return Unsafe.SizeOf<T>() switch
+        return H.SizeOf<T>() switch
         {
             1 => core<sbyte>(x),
             2 => core<short>(x),
@@ -63,7 +62,7 @@ partial class VectorOp
     private class Sign_<T> : Const<T> where T : unmanaged
     {
         internal static readonly Vector<T> SignBit = GetSignBit();
-        static Vector<T> GetSignBit() => Unsafe.SizeOf<T>() switch
+        static Vector<T> GetSignBit() => H.SizeOf<T>() switch
         {
             1 => As<byte  >(new(0x80)),
             2 => As<ushort>(new(0x8000)),

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._MathEx.DivideLike.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._MathEx.DivideLike.cs
@@ -16,11 +16,11 @@ partial class VectorOp
     {
         if (typeof(T) == typeof(float))
         {
-            return H.Reinterpret<float, T>(Floor<float>(H.Reinterpret<T, float>(a) / H.Reinterpret<T, float>(b)));
+            return H.BitCastV<float, T>(Floor<float>(H.BitCastV<T, float>(a) / H.BitCastV<T, float>(b)));
         }
         if (typeof(T) == typeof(double))
         {
-            return H.Reinterpret<double, T>(Floor<double>(H.Reinterpret<T, double>(a) / H.Reinterpret<T, double>(b)));
+            return H.BitCastV<double, T>(Floor<double>(H.BitCastV<T, double>(a) / H.BitCastV<T, double>(b)));
         }
         if (typeof(T) == typeof(byte)
             || typeof(T) == typeof(ushort)
@@ -59,11 +59,11 @@ partial class VectorOp
     {
         if (typeof(T) == typeof(float))
         {
-            return H.Reinterpret<float, T>(Ceiling<float>(H.Reinterpret<T, float>(a) / H.Reinterpret<T, float>(b)));
+            return H.BitCastV<float, T>(Ceiling<float>(H.BitCastV<T, float>(a) / H.BitCastV<T, float>(b)));
         }
         if (typeof(T) == typeof(double))
         {
-            return H.Reinterpret<double, T>(Ceiling<double>(H.Reinterpret<T, double>(a) / H.Reinterpret<T, double>(b)));
+            return H.BitCastV<double, T>(Ceiling<double>(H.BitCastV<T, double>(a) / H.BitCastV<T, double>(b)));
         }
         if (typeof(T) == typeof(sbyte)
             || typeof(T) == typeof(short)

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._MathEx.ModuloByConst.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._MathEx.ModuloByConst.cs
@@ -60,16 +60,16 @@ partial class VectorOp
         where T : unmanaged
     {
 #pragma warning disable format
-        if (typeof(T) == typeof(byte  )) return H.Reinterpret<byte  , T>(H.Reinterpret<T, byte  >(x & ModuloByConst_<T>._1));
-        if (typeof(T) == typeof(ushort)) return H.Reinterpret<ushort, T>(H.Reinterpret<T, ushort>(x & ModuloByConst_<T>._1));
-        if (typeof(T) == typeof(uint  )) return H.Reinterpret<uint  , T>(H.Reinterpret<T, uint  >(x & ModuloByConst_<T>._1));
-        if (typeof(T) == typeof(ulong )) return H.Reinterpret<ulong , T>(H.Reinterpret<T, ulong >(x & ModuloByConst_<T>._1));
-        if (typeof(T) == typeof(sbyte )) return H.Reinterpret<sbyte , T>(H.Reinterpret<T, sbyte >(x & ModuloByConst_<T>._1));
-        if (typeof(T) == typeof(short )) return H.Reinterpret<short , T>(H.Reinterpret<T, short >(x & ModuloByConst_<T>._1));
-        if (typeof(T) == typeof(int   )) return H.Reinterpret<int   , T>(H.Reinterpret<T, int   >(x & ModuloByConst_<T>._1));
-        if (typeof(T) == typeof(long  )) return H.Reinterpret<long  , T>(H.Reinterpret<T, long  >(x & ModuloByConst_<T>._1));
-        if (typeof(T) == typeof(float )) return H.Reinterpret<float , T>(ModuloBy2(H.Reinterpret<T, float >(x)));
-        if (typeof(T) == typeof(double)) return H.Reinterpret<double, T>(ModuloBy2(H.Reinterpret<T, double>(x)));
+        if (typeof(T) == typeof(byte  )) return H.BitCastV<byte  , T>(H.BitCastV<T, byte  >(x & ModuloByConst_<T>._1));
+        if (typeof(T) == typeof(ushort)) return H.BitCastV<ushort, T>(H.BitCastV<T, ushort>(x & ModuloByConst_<T>._1));
+        if (typeof(T) == typeof(uint  )) return H.BitCastV<uint  , T>(H.BitCastV<T, uint  >(x & ModuloByConst_<T>._1));
+        if (typeof(T) == typeof(ulong )) return H.BitCastV<ulong , T>(H.BitCastV<T, ulong >(x & ModuloByConst_<T>._1));
+        if (typeof(T) == typeof(sbyte )) return H.BitCastV<sbyte , T>(H.BitCastV<T, sbyte >(x & ModuloByConst_<T>._1));
+        if (typeof(T) == typeof(short )) return H.BitCastV<short , T>(H.BitCastV<T, short >(x & ModuloByConst_<T>._1));
+        if (typeof(T) == typeof(int   )) return H.BitCastV<int   , T>(H.BitCastV<T, int   >(x & ModuloByConst_<T>._1));
+        if (typeof(T) == typeof(long  )) return H.BitCastV<long  , T>(H.BitCastV<T, long  >(x & ModuloByConst_<T>._1));
+        if (typeof(T) == typeof(float )) return H.BitCastV<float , T>(ModuloBy2(H.BitCastV<T, float >(x)));
+        if (typeof(T) == typeof(double)) return H.BitCastV<double, T>(ModuloBy2(H.BitCastV<T, double>(x)));
 #pragma warning restore format
         throw new NotSupportedException();
     }

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._Operator.Modulo.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._Operator.Modulo.cs
@@ -29,11 +29,11 @@ partial class VectorOp
     {
         if (typeof(T) == typeof(float))
         {
-            return H.Reinterpret<float, T>(Modulo(H.Reinterpret<T, float>(x), H.Reinterpret<T, float>(y)));
+            return H.BitCastV<float, T>(Modulo(H.BitCastV<T, float>(x), H.BitCastV<T, float>(y)));
         }
         if (typeof(T) == typeof(double))
         {
-            return H.Reinterpret<double, T>(Modulo(H.Reinterpret<T, double>(x), H.Reinterpret<T, double>(y)));
+            return H.BitCastV<double, T>(Modulo(H.BitCastV<T, double>(x), H.BitCastV<T, double>(y)));
         }
         return x - y * (x / y);
     }
@@ -52,35 +52,35 @@ partial class VectorOp
         var i = n - m;
         var shouldReturnX = LessThan(i, Vector<int>.Zero);
 
-        var c = H.Reinterpret<int, uint>(a | Const.SingleEconomizedBit);
-        var d = H.Reinterpret<int, uint>(b | Const.SingleEconomizedBit);
+        var c = H.BitCastV<int, uint>(a | Const.SingleEconomizedBit);
+        var d = H.BitCastV<int, uint>(b | Const.SingleEconomizedBit);
         while(true)
         {
-            var condition = H.Reinterpret<int, uint>(GreaterThan(i, Const.SingleExponentBits));
+            var condition = H.BitCastV<int, uint>(GreaterThan(i, Const.SingleExponentBits));
             if(NVector.EqualsAll(condition, VectorOp.Const<uint>.FalseValue))
             {
                 break;
             }
-            var nextC = ShiftLeft(c, H.Reinterpret<int, uint>(Const.SingleExponentBits));
+            var nextC = ShiftLeft(c, H.BitCastV<int, uint>(Const.SingleExponentBits));
             nextC -= d * (nextC / d);
             c = ConditionalSelect(condition, nextC, c);
-            i = ConditionalSelect(H.Reinterpret<uint, int>(condition), i - Const.SingleExponentBits, i);
+            i = ConditionalSelect(H.BitCastV<uint, int>(condition), i - Const.SingleExponentBits, i);
         }
-        c = ShiftLeft(c, H.Reinterpret<int, uint>(i));
+        c = ShiftLeft(c, H.BitCastV<int, uint>(i));
         c -= d * (c / d);
         i = Vector<int>.Zero;
 
         var shouldReturnZero = Equals(c, Vector<uint>.Zero);
         var eBitShift = VectorOp.CountLeadingZeros(c) - Const.SingleEBitPosFromLeft;
         c = ShiftLeft(c, eBitShift);
-        i -= H.Reinterpret<uint, int>(eBitShift);
+        i -= H.BitCastV<uint, int>(eBitShift);
         
-        var retval = VectorOp.Scale(s, m + i, H.Reinterpret<uint, int>(c) & VectorOp.IEEE754Single_.FracPartMask);
+        var retval = VectorOp.Scale(s, m + i, H.BitCastV<uint, int>(c) & VectorOp.IEEE754Single_.FracPartMask);
         return ConditionalSelect(
-            H.Reinterpret<int, float>(shouldReturnX),
+            H.BitCastV<int, float>(shouldReturnX),
             x,
             ConditionalSelect(
-                H.Reinterpret<uint, float>(shouldReturnZero),
+                H.BitCastV<uint, float>(shouldReturnZero),
                 Vector<float>.Zero,
                 retval));
     }
@@ -99,35 +99,35 @@ partial class VectorOp
         var i = n - m;
         var shouldReturnX = LessThan(i, Vector<long>.Zero);
 
-        var c = H.Reinterpret<long, ulong>(a | Const.DoubleEconomizedBit);
-        var d = H.Reinterpret<long, ulong>(b | Const.DoubleEconomizedBit);
+        var c = H.BitCastV<long, ulong>(a | Const.DoubleEconomizedBit);
+        var d = H.BitCastV<long, ulong>(b | Const.DoubleEconomizedBit);
         while (true)
         {
-            var condition = H.Reinterpret<long, ulong>(GreaterThan(i, Const.DoubleExponentBits));
+            var condition = H.BitCastV<long, ulong>(GreaterThan(i, Const.DoubleExponentBits));
             if (NVector.EqualsAll(condition, VectorOp.Const<ulong>.FalseValue))
             {
                 break;
             }
-            var nextC = ShiftLeft(c, H.Reinterpret<long, ulong>(Const.DoubleExponentBits));
+            var nextC = ShiftLeft(c, H.BitCastV<long, ulong>(Const.DoubleExponentBits));
             nextC -= d * (nextC / d);
             c = ConditionalSelect(condition, nextC, c);
-            i = ConditionalSelect(H.Reinterpret<ulong, long>(condition), i - Const.DoubleExponentBits, i);
+            i = ConditionalSelect(H.BitCastV<ulong, long>(condition), i - Const.DoubleExponentBits, i);
         }
-        c = ShiftLeft(c, H.Reinterpret<long, ulong>(i));
+        c = ShiftLeft(c, H.BitCastV<long, ulong>(i));
         c -= d * (c / d);
         i = Vector<long>.Zero;
 
         var shouldReturnZero = Equals(c, Vector<ulong>.Zero);
         var eBitShift = VectorOp.CountLeadingZeros(c) - Const.DoubleEBitPosFromLeft;
         c = ShiftLeft(c, eBitShift);
-        i -= H.Reinterpret<ulong, long>(eBitShift);
+        i -= H.BitCastV<ulong, long>(eBitShift);
 
-        var retval = VectorOp.Scale(s, m + i, H.Reinterpret<ulong, long>(c) & VectorOp.IEEE754Double_.FracPartMask);
+        var retval = VectorOp.Scale(s, m + i, H.BitCastV<ulong, long>(c) & VectorOp.IEEE754Double_.FracPartMask);
         return ConditionalSelect(
-            H.Reinterpret<long, double>(shouldReturnX),
+            H.BitCastV<long, double>(shouldReturnX),
             x,
             ConditionalSelect(
-                H.Reinterpret<ulong, double>(shouldReturnZero),
+                H.BitCastV<ulong, double>(shouldReturnZero),
                 Vector<double>.Zero,
                 retval));
     }

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._Operator.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._Operator.cs
@@ -340,16 +340,16 @@ public static partial class VectorOp
     public static Vector<T> ShiftLeft<T>(Vector<T> value, int shiftCount)
         where T : unmanaged
     {
-        if(typeof(T) == typeof(byte  )) { return H.Reinterpret<byte  , T>(ShiftLeft(H.Reinterpret<T, byte  >(value), shiftCount)); }
-        if(typeof(T) == typeof(ushort)) { return H.Reinterpret<ushort, T>(ShiftLeft(H.Reinterpret<T, ushort>(value), shiftCount)); }
-        if(typeof(T) == typeof(uint  )) { return H.Reinterpret<uint  , T>(ShiftLeft(H.Reinterpret<T, uint  >(value), shiftCount)); }
-        if(typeof(T) == typeof(ulong )) { return H.Reinterpret<ulong , T>(ShiftLeft(H.Reinterpret<T, ulong >(value), shiftCount)); }
-        if(typeof(T) == typeof(nuint )) { return H.Reinterpret<nuint , T>(ShiftLeft(H.Reinterpret<T, nuint >(value), shiftCount)); }
-        if(typeof(T) == typeof(sbyte )) { return H.Reinterpret<sbyte , T>(ShiftLeft(H.Reinterpret<T, sbyte >(value), shiftCount)); }
-        if(typeof(T) == typeof(short )) { return H.Reinterpret<short , T>(ShiftLeft(H.Reinterpret<T, short >(value), shiftCount)); }
-        if(typeof(T) == typeof(int   )) { return H.Reinterpret<int   , T>(ShiftLeft(H.Reinterpret<T, int   >(value), shiftCount)); }
-        if(typeof(T) == typeof(long  )) { return H.Reinterpret<long  , T>(ShiftLeft(H.Reinterpret<T, long  >(value), shiftCount)); }
-        if(typeof(T) == typeof(nint  )) { return H.Reinterpret<nint  , T>(ShiftLeft(H.Reinterpret<T, nint  >(value), shiftCount)); }
+        if(typeof(T) == typeof(byte  )) { return H.BitCastV<byte  , T>(ShiftLeft(H.BitCastV<T, byte  >(value), shiftCount)); }
+        if(typeof(T) == typeof(ushort)) { return H.BitCastV<ushort, T>(ShiftLeft(H.BitCastV<T, ushort>(value), shiftCount)); }
+        if(typeof(T) == typeof(uint  )) { return H.BitCastV<uint  , T>(ShiftLeft(H.BitCastV<T, uint  >(value), shiftCount)); }
+        if(typeof(T) == typeof(ulong )) { return H.BitCastV<ulong , T>(ShiftLeft(H.BitCastV<T, ulong >(value), shiftCount)); }
+        if(typeof(T) == typeof(nuint )) { return H.BitCastV<nuint , T>(ShiftLeft(H.BitCastV<T, nuint >(value), shiftCount)); }
+        if(typeof(T) == typeof(sbyte )) { return H.BitCastV<sbyte , T>(ShiftLeft(H.BitCastV<T, sbyte >(value), shiftCount)); }
+        if(typeof(T) == typeof(short )) { return H.BitCastV<short , T>(ShiftLeft(H.BitCastV<T, short >(value), shiftCount)); }
+        if(typeof(T) == typeof(int   )) { return H.BitCastV<int   , T>(ShiftLeft(H.BitCastV<T, int   >(value), shiftCount)); }
+        if(typeof(T) == typeof(long  )) { return H.BitCastV<long  , T>(ShiftLeft(H.BitCastV<T, long  >(value), shiftCount)); }
+        if(typeof(T) == typeof(nint  )) { return H.BitCastV<nint  , T>(ShiftLeft(H.BitCastV<T, nint  >(value), shiftCount)); }
         throw new NotSupportedException();
     }
     
@@ -358,16 +358,16 @@ public static partial class VectorOp
     public static Vector<T> ShiftLeft<T>(Vector<T> value, Vector<T> shiftCount)
         where T : unmanaged
     {
-        if(typeof(T) == typeof(byte  )) { return H.Reinterpret<byte  , T>(ShiftLeft(H.Reinterpret<T, byte  >(value), H.Reinterpret<T, byte  >(shiftCount))); }
-        if(typeof(T) == typeof(ushort)) { return H.Reinterpret<ushort, T>(ShiftLeft(H.Reinterpret<T, ushort>(value), H.Reinterpret<T, ushort>(shiftCount))); }
-        if(typeof(T) == typeof(uint  )) { return H.Reinterpret<uint  , T>(ShiftLeft(H.Reinterpret<T, uint  >(value), H.Reinterpret<T, uint  >(shiftCount))); }
-        if(typeof(T) == typeof(ulong )) { return H.Reinterpret<ulong , T>(ShiftLeft(H.Reinterpret<T, ulong >(value), H.Reinterpret<T, ulong >(shiftCount))); }
-        if(typeof(T) == typeof(nuint )) { return H.Reinterpret<nuint , T>(ShiftLeft(H.Reinterpret<T, nuint >(value), H.Reinterpret<T, nuint >(shiftCount))); }
-        if(typeof(T) == typeof(sbyte )) { return H.Reinterpret<sbyte , T>(ShiftLeft(H.Reinterpret<T, sbyte >(value), H.Reinterpret<T, sbyte >(shiftCount))); }
-        if(typeof(T) == typeof(short )) { return H.Reinterpret<short , T>(ShiftLeft(H.Reinterpret<T, short >(value), H.Reinterpret<T, short >(shiftCount))); }
-        if(typeof(T) == typeof(int   )) { return H.Reinterpret<int   , T>(ShiftLeft(H.Reinterpret<T, int   >(value), H.Reinterpret<T, int   >(shiftCount))); }
-        if(typeof(T) == typeof(long  )) { return H.Reinterpret<long  , T>(ShiftLeft(H.Reinterpret<T, long  >(value), H.Reinterpret<T, long  >(shiftCount))); }
-        if(typeof(T) == typeof(nint  )) { return H.Reinterpret<nint  , T>(ShiftLeft(H.Reinterpret<T, nint  >(value), H.Reinterpret<T, nint  >(shiftCount))); }
+        if(typeof(T) == typeof(byte  )) { return H.BitCastV<byte  , T>(ShiftLeft(H.BitCastV<T, byte  >(value), H.BitCastV<T, byte  >(shiftCount))); }
+        if(typeof(T) == typeof(ushort)) { return H.BitCastV<ushort, T>(ShiftLeft(H.BitCastV<T, ushort>(value), H.BitCastV<T, ushort>(shiftCount))); }
+        if(typeof(T) == typeof(uint  )) { return H.BitCastV<uint  , T>(ShiftLeft(H.BitCastV<T, uint  >(value), H.BitCastV<T, uint  >(shiftCount))); }
+        if(typeof(T) == typeof(ulong )) { return H.BitCastV<ulong , T>(ShiftLeft(H.BitCastV<T, ulong >(value), H.BitCastV<T, ulong >(shiftCount))); }
+        if(typeof(T) == typeof(nuint )) { return H.BitCastV<nuint , T>(ShiftLeft(H.BitCastV<T, nuint >(value), H.BitCastV<T, nuint >(shiftCount))); }
+        if(typeof(T) == typeof(sbyte )) { return H.BitCastV<sbyte , T>(ShiftLeft(H.BitCastV<T, sbyte >(value), H.BitCastV<T, sbyte >(shiftCount))); }
+        if(typeof(T) == typeof(short )) { return H.BitCastV<short , T>(ShiftLeft(H.BitCastV<T, short >(value), H.BitCastV<T, short >(shiftCount))); }
+        if(typeof(T) == typeof(int   )) { return H.BitCastV<int   , T>(ShiftLeft(H.BitCastV<T, int   >(value), H.BitCastV<T, int   >(shiftCount))); }
+        if(typeof(T) == typeof(long  )) { return H.BitCastV<long  , T>(ShiftLeft(H.BitCastV<T, long  >(value), H.BitCastV<T, long  >(shiftCount))); }
+        if(typeof(T) == typeof(nint  )) { return H.BitCastV<nint  , T>(ShiftLeft(H.BitCastV<T, nint  >(value), H.BitCastV<T, nint  >(shiftCount))); }
         throw new NotSupportedException();
     }
     
@@ -376,16 +376,16 @@ public static partial class VectorOp
     public static Vector<T> ShiftRightLogical<T>(Vector<T> value, int shiftCount)
         where T : unmanaged
     {
-        if(typeof(T) == typeof(byte  )) { return H.Reinterpret<byte  , T>(ShiftRightLogical(H.Reinterpret<T, byte  >(value), shiftCount)); }
-        if(typeof(T) == typeof(ushort)) { return H.Reinterpret<ushort, T>(ShiftRightLogical(H.Reinterpret<T, ushort>(value), shiftCount)); }
-        if(typeof(T) == typeof(uint  )) { return H.Reinterpret<uint  , T>(ShiftRightLogical(H.Reinterpret<T, uint  >(value), shiftCount)); }
-        if(typeof(T) == typeof(ulong )) { return H.Reinterpret<ulong , T>(ShiftRightLogical(H.Reinterpret<T, ulong >(value), shiftCount)); }
-        if(typeof(T) == typeof(nuint )) { return H.Reinterpret<nuint , T>(ShiftRightLogical(H.Reinterpret<T, nuint >(value), shiftCount)); }
-        if(typeof(T) == typeof(sbyte )) { return H.Reinterpret<sbyte , T>(ShiftRightLogical(H.Reinterpret<T, sbyte >(value), shiftCount)); }
-        if(typeof(T) == typeof(short )) { return H.Reinterpret<short , T>(ShiftRightLogical(H.Reinterpret<T, short >(value), shiftCount)); }
-        if(typeof(T) == typeof(int   )) { return H.Reinterpret<int   , T>(ShiftRightLogical(H.Reinterpret<T, int   >(value), shiftCount)); }
-        if(typeof(T) == typeof(long  )) { return H.Reinterpret<long  , T>(ShiftRightLogical(H.Reinterpret<T, long  >(value), shiftCount)); }
-        if(typeof(T) == typeof(nint  )) { return H.Reinterpret<nint  , T>(ShiftRightLogical(H.Reinterpret<T, nint  >(value), shiftCount)); }
+        if(typeof(T) == typeof(byte  )) { return H.BitCastV<byte  , T>(ShiftRightLogical(H.BitCastV<T, byte  >(value), shiftCount)); }
+        if(typeof(T) == typeof(ushort)) { return H.BitCastV<ushort, T>(ShiftRightLogical(H.BitCastV<T, ushort>(value), shiftCount)); }
+        if(typeof(T) == typeof(uint  )) { return H.BitCastV<uint  , T>(ShiftRightLogical(H.BitCastV<T, uint  >(value), shiftCount)); }
+        if(typeof(T) == typeof(ulong )) { return H.BitCastV<ulong , T>(ShiftRightLogical(H.BitCastV<T, ulong >(value), shiftCount)); }
+        if(typeof(T) == typeof(nuint )) { return H.BitCastV<nuint , T>(ShiftRightLogical(H.BitCastV<T, nuint >(value), shiftCount)); }
+        if(typeof(T) == typeof(sbyte )) { return H.BitCastV<sbyte , T>(ShiftRightLogical(H.BitCastV<T, sbyte >(value), shiftCount)); }
+        if(typeof(T) == typeof(short )) { return H.BitCastV<short , T>(ShiftRightLogical(H.BitCastV<T, short >(value), shiftCount)); }
+        if(typeof(T) == typeof(int   )) { return H.BitCastV<int   , T>(ShiftRightLogical(H.BitCastV<T, int   >(value), shiftCount)); }
+        if(typeof(T) == typeof(long  )) { return H.BitCastV<long  , T>(ShiftRightLogical(H.BitCastV<T, long  >(value), shiftCount)); }
+        if(typeof(T) == typeof(nint  )) { return H.BitCastV<nint  , T>(ShiftRightLogical(H.BitCastV<T, nint  >(value), shiftCount)); }
         throw new NotSupportedException();
     }
     
@@ -394,16 +394,16 @@ public static partial class VectorOp
     public static Vector<T> ShiftRightLogical<T>(Vector<T> value, Vector<T> shiftCount)
         where T : unmanaged
     {
-        if(typeof(T) == typeof(byte  )) { return H.Reinterpret<byte  , T>(ShiftRightLogical(H.Reinterpret<T, byte  >(value), H.Reinterpret<T, byte  >(shiftCount))); }
-        if(typeof(T) == typeof(ushort)) { return H.Reinterpret<ushort, T>(ShiftRightLogical(H.Reinterpret<T, ushort>(value), H.Reinterpret<T, ushort>(shiftCount))); }
-        if(typeof(T) == typeof(uint  )) { return H.Reinterpret<uint  , T>(ShiftRightLogical(H.Reinterpret<T, uint  >(value), H.Reinterpret<T, uint  >(shiftCount))); }
-        if(typeof(T) == typeof(ulong )) { return H.Reinterpret<ulong , T>(ShiftRightLogical(H.Reinterpret<T, ulong >(value), H.Reinterpret<T, ulong >(shiftCount))); }
-        if(typeof(T) == typeof(nuint )) { return H.Reinterpret<nuint , T>(ShiftRightLogical(H.Reinterpret<T, nuint >(value), H.Reinterpret<T, nuint >(shiftCount))); }
-        if(typeof(T) == typeof(sbyte )) { return H.Reinterpret<sbyte , T>(ShiftRightLogical(H.Reinterpret<T, sbyte >(value), H.Reinterpret<T, sbyte >(shiftCount))); }
-        if(typeof(T) == typeof(short )) { return H.Reinterpret<short , T>(ShiftRightLogical(H.Reinterpret<T, short >(value), H.Reinterpret<T, short >(shiftCount))); }
-        if(typeof(T) == typeof(int   )) { return H.Reinterpret<int   , T>(ShiftRightLogical(H.Reinterpret<T, int   >(value), H.Reinterpret<T, int   >(shiftCount))); }
-        if(typeof(T) == typeof(long  )) { return H.Reinterpret<long  , T>(ShiftRightLogical(H.Reinterpret<T, long  >(value), H.Reinterpret<T, long  >(shiftCount))); }
-        if(typeof(T) == typeof(nint  )) { return H.Reinterpret<nint  , T>(ShiftRightLogical(H.Reinterpret<T, nint  >(value), H.Reinterpret<T, nint  >(shiftCount))); }
+        if(typeof(T) == typeof(byte  )) { return H.BitCastV<byte  , T>(ShiftRightLogical(H.BitCastV<T, byte  >(value), H.BitCastV<T, byte  >(shiftCount))); }
+        if(typeof(T) == typeof(ushort)) { return H.BitCastV<ushort, T>(ShiftRightLogical(H.BitCastV<T, ushort>(value), H.BitCastV<T, ushort>(shiftCount))); }
+        if(typeof(T) == typeof(uint  )) { return H.BitCastV<uint  , T>(ShiftRightLogical(H.BitCastV<T, uint  >(value), H.BitCastV<T, uint  >(shiftCount))); }
+        if(typeof(T) == typeof(ulong )) { return H.BitCastV<ulong , T>(ShiftRightLogical(H.BitCastV<T, ulong >(value), H.BitCastV<T, ulong >(shiftCount))); }
+        if(typeof(T) == typeof(nuint )) { return H.BitCastV<nuint , T>(ShiftRightLogical(H.BitCastV<T, nuint >(value), H.BitCastV<T, nuint >(shiftCount))); }
+        if(typeof(T) == typeof(sbyte )) { return H.BitCastV<sbyte , T>(ShiftRightLogical(H.BitCastV<T, sbyte >(value), H.BitCastV<T, sbyte >(shiftCount))); }
+        if(typeof(T) == typeof(short )) { return H.BitCastV<short , T>(ShiftRightLogical(H.BitCastV<T, short >(value), H.BitCastV<T, short >(shiftCount))); }
+        if(typeof(T) == typeof(int   )) { return H.BitCastV<int   , T>(ShiftRightLogical(H.BitCastV<T, int   >(value), H.BitCastV<T, int   >(shiftCount))); }
+        if(typeof(T) == typeof(long  )) { return H.BitCastV<long  , T>(ShiftRightLogical(H.BitCastV<T, long  >(value), H.BitCastV<T, long  >(shiftCount))); }
+        if(typeof(T) == typeof(nint  )) { return H.BitCastV<nint  , T>(ShiftRightLogical(H.BitCastV<T, nint  >(value), H.BitCastV<T, nint  >(shiftCount))); }
         throw new NotSupportedException();
     }
     
@@ -412,11 +412,11 @@ public static partial class VectorOp
     public static Vector<T> ShiftRightArithmetic<T>(Vector<T> value, int shiftCount)
         where T : unmanaged
     {
-        if(typeof(T) == typeof(sbyte )) { return H.Reinterpret<sbyte , T>(ShiftRightArithmetic(H.Reinterpret<T, sbyte >(value), shiftCount)); }
-        if(typeof(T) == typeof(short )) { return H.Reinterpret<short , T>(ShiftRightArithmetic(H.Reinterpret<T, short >(value), shiftCount)); }
-        if(typeof(T) == typeof(int   )) { return H.Reinterpret<int   , T>(ShiftRightArithmetic(H.Reinterpret<T, int   >(value), shiftCount)); }
-        if(typeof(T) == typeof(long  )) { return H.Reinterpret<long  , T>(ShiftRightArithmetic(H.Reinterpret<T, long  >(value), shiftCount)); }
-        if(typeof(T) == typeof(nint  )) { return H.Reinterpret<nint  , T>(ShiftRightArithmetic(H.Reinterpret<T, nint  >(value), shiftCount)); }
+        if(typeof(T) == typeof(sbyte )) { return H.BitCastV<sbyte , T>(ShiftRightArithmetic(H.BitCastV<T, sbyte >(value), shiftCount)); }
+        if(typeof(T) == typeof(short )) { return H.BitCastV<short , T>(ShiftRightArithmetic(H.BitCastV<T, short >(value), shiftCount)); }
+        if(typeof(T) == typeof(int   )) { return H.BitCastV<int   , T>(ShiftRightArithmetic(H.BitCastV<T, int   >(value), shiftCount)); }
+        if(typeof(T) == typeof(long  )) { return H.BitCastV<long  , T>(ShiftRightArithmetic(H.BitCastV<T, long  >(value), shiftCount)); }
+        if(typeof(T) == typeof(nint  )) { return H.BitCastV<nint  , T>(ShiftRightArithmetic(H.BitCastV<T, nint  >(value), shiftCount)); }
         throw new NotSupportedException();
     }
     
@@ -425,11 +425,11 @@ public static partial class VectorOp
     public static Vector<T> ShiftRightArithmetic<T>(Vector<T> value, Vector<T> shiftCount)
         where T : unmanaged
     {
-        if(typeof(T) == typeof(sbyte )) { return H.Reinterpret<sbyte , T>(ShiftRightArithmetic(H.Reinterpret<T, sbyte >(value), H.Reinterpret<T, sbyte >(shiftCount))); }
-        if(typeof(T) == typeof(short )) { return H.Reinterpret<short , T>(ShiftRightArithmetic(H.Reinterpret<T, short >(value), H.Reinterpret<T, short >(shiftCount))); }
-        if(typeof(T) == typeof(int   )) { return H.Reinterpret<int   , T>(ShiftRightArithmetic(H.Reinterpret<T, int   >(value), H.Reinterpret<T, int   >(shiftCount))); }
-        if(typeof(T) == typeof(long  )) { return H.Reinterpret<long  , T>(ShiftRightArithmetic(H.Reinterpret<T, long  >(value), H.Reinterpret<T, long  >(shiftCount))); }
-        if(typeof(T) == typeof(nint  )) { return H.Reinterpret<nint  , T>(ShiftRightArithmetic(H.Reinterpret<T, nint  >(value), H.Reinterpret<T, nint  >(shiftCount))); }
+        if(typeof(T) == typeof(sbyte )) { return H.BitCastV<sbyte , T>(ShiftRightArithmetic(H.BitCastV<T, sbyte >(value), H.BitCastV<T, sbyte >(shiftCount))); }
+        if(typeof(T) == typeof(short )) { return H.BitCastV<short , T>(ShiftRightArithmetic(H.BitCastV<T, short >(value), H.BitCastV<T, short >(shiftCount))); }
+        if(typeof(T) == typeof(int   )) { return H.BitCastV<int   , T>(ShiftRightArithmetic(H.BitCastV<T, int   >(value), H.BitCastV<T, int   >(shiftCount))); }
+        if(typeof(T) == typeof(long  )) { return H.BitCastV<long  , T>(ShiftRightArithmetic(H.BitCastV<T, long  >(value), H.BitCastV<T, long  >(shiftCount))); }
+        if(typeof(T) == typeof(nint  )) { return H.BitCastV<nint  , T>(ShiftRightArithmetic(H.BitCastV<T, nint  >(value), H.BitCastV<T, nint  >(shiftCount))); }
         throw new NotSupportedException();
     }
 

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._OperatorEx.Saturate.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._OperatorEx.Saturate.cs
@@ -25,19 +25,19 @@ partial class VectorOp
 #if NETCOREAPP3_0_OR_GREATER
         if(typeof(T) == typeof(byte))
         {
-            return H.Reinterpret<byte, T>(AddSaturateCore(H.Reinterpret<T, byte>( lhs), H.Reinterpret<T, byte>(rhs)));
+            return H.BitCastV<byte, T>(AddSaturateCore(H.BitCastV<T, byte>( lhs), H.BitCastV<T, byte>(rhs)));
         }
         if (typeof(T) == typeof(sbyte))
         {
-            return H.Reinterpret<sbyte, T>(AddSaturateCore(H.Reinterpret<T, sbyte>(lhs), H.Reinterpret<T, sbyte>(rhs)));
+            return H.BitCastV<sbyte, T>(AddSaturateCore(H.BitCastV<T, sbyte>(lhs), H.BitCastV<T, sbyte>(rhs)));
         }
         if (typeof(T) == typeof(ushort))
         {
-            return H.Reinterpret<ushort, T>(AddSaturateCore(H.Reinterpret<T, ushort>(lhs), H.Reinterpret<T, ushort>(rhs)));
+            return H.BitCastV<ushort, T>(AddSaturateCore(H.BitCastV<T, ushort>(lhs), H.BitCastV<T, ushort>(rhs)));
         }
         if (typeof(T) == typeof(short))
         {
-            return H.Reinterpret<short, T>(AddSaturateCore(H.Reinterpret<T, short>(lhs), H.Reinterpret<T, short>(rhs)));
+            return H.BitCastV<short, T>(AddSaturateCore(H.BitCastV<T, short>(lhs), H.BitCastV<T, short>(rhs)));
         }
 #endif
         if (typeof(T) == typeof(byte) || typeof(T) == typeof(ushort) || typeof(T) == typeof(uint) || typeof(T) == typeof(ulong) || typeof(T) == typeof(nuint))
@@ -149,19 +149,19 @@ partial class VectorOp
 #if NETCOREAPP3_0_OR_GREATER
         if (typeof(T) == typeof(byte))
         {
-            return H.Reinterpret<byte, T>(SubtractSaturateCore(H.Reinterpret<T, byte>(lhs), H.Reinterpret<T, byte>(rhs)));
+            return H.BitCastV<byte, T>(SubtractSaturateCore(H.BitCastV<T, byte>(lhs), H.BitCastV<T, byte>(rhs)));
         }
         if (typeof(T) == typeof(sbyte))
         {
-            return H.Reinterpret<sbyte, T>(SubtractSaturateCore(H.Reinterpret<T, sbyte>(lhs), H.Reinterpret<T, sbyte>(rhs)));
+            return H.BitCastV<sbyte, T>(SubtractSaturateCore(H.BitCastV<T, sbyte>(lhs), H.BitCastV<T, sbyte>(rhs)));
         }
         if (typeof(T) == typeof(ushort))
         {
-            return H.Reinterpret<ushort, T>(SubtractSaturateCore(H.Reinterpret<T, ushort>(lhs), H.Reinterpret<T, ushort>(rhs)));
+            return H.BitCastV<ushort, T>(SubtractSaturateCore(H.BitCastV<T, ushort>(lhs), H.BitCastV<T, ushort>(rhs)));
         }
         if (typeof(T) == typeof(short))
         {
-            return H.Reinterpret<short, T>(SubtractSaturateCore(H.Reinterpret<T, short>(lhs), H.Reinterpret<T, short>(rhs)));
+            return H.BitCastV<short, T>(SubtractSaturateCore(H.BitCastV<T, short>(lhs), H.BitCastV<T, short>(rhs)));
         }
 #endif
         if (typeof(T) == typeof(byte) || typeof(T) == typeof(ushort) || typeof(T) == typeof(uint) || typeof(T) == typeof(ulong) || typeof(T) == typeof(nuint))

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._Vector.Blend.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._Vector.Blend.cs
@@ -37,9 +37,9 @@ partial class VectorOp
     internal static Vector<ulong> Blend(Vector<ulong> x, Vector<ulong> y, [ConstantExpected] byte mask)
     {
         if (Avx.IsSupported && Vector<ulong>.Count == Vector256<ulong>.Count)
-            return H.Reinterpret<Vector256<double>, Vector<ulong>>(Avx.Blend(
-                H.Reinterpret<Vector<ulong>, Vector256<double>>(x),
-                H.Reinterpret<Vector<ulong>, Vector256<double>>(y),
+            return H.BitCast<Vector256<double>, Vector<ulong>>(Avx.Blend(
+                H.BitCast<Vector<ulong>, Vector256<double>>(x),
+                H.BitCast<Vector<ulong>, Vector256<double>>(y),
                 mask));
         return Blend_Fallback(x, y, mask);
     }
@@ -77,18 +77,18 @@ partial class VectorOp
 #if NET7_0_OR_GREATER
     public static Vector<T> Blend<T>(Vector<T> x, Vector<T> y, [ConstantExpected] byte mask)
         where T : unmanaged
-        => Unsafe.SizeOf<T>() switch
+        => H.SizeOf<T>() switch
         {
-            sizeof(byte  ) => H.Reinterpret<byte  , T>(Blend(H.Reinterpret<T, byte  >(x), H.Reinterpret<T, byte  >(y), mask)),
-            sizeof(ushort) => H.Reinterpret<ushort, T>(Blend(H.Reinterpret<T, ushort>(x), H.Reinterpret<T, ushort>(y), mask)),
-            sizeof(uint  ) => H.Reinterpret<uint  , T>(Blend(H.Reinterpret<T, uint  >(x), H.Reinterpret<T, uint  >(y), mask)),
-            sizeof(ulong ) => H.Reinterpret<ulong , T>(Blend(H.Reinterpret<T, ulong >(x), H.Reinterpret<T, ulong >(y), mask)),
+            sizeof(byte  ) => H.BitCastV<byte  , T>(Blend(H.BitCastV<T, byte  >(x), H.BitCastV<T, byte  >(y), mask)),
+            sizeof(ushort) => H.BitCastV<ushort, T>(Blend(H.BitCastV<T, ushort>(x), H.BitCastV<T, ushort>(y), mask)),
+            sizeof(uint  ) => H.BitCastV<uint  , T>(Blend(H.BitCastV<T, uint  >(x), H.BitCastV<T, uint  >(y), mask)),
+            sizeof(ulong ) => H.BitCastV<ulong , T>(Blend(H.BitCastV<T, ulong >(x), H.BitCastV<T, ulong >(y), mask)),
             _ => throw new NotSupportedException(),
         };
 #elif NETCOREAPP3_0_OR_GREATER
     public static Vector<T> Blend<T>(Vector<T> x, Vector<T> y, byte mask)
         where T : unmanaged
-        => Unsafe.SizeOf<T>() switch
+        => H.SizeOf<T>() switch
         {
             sizeof(byte  ) => H.Reinterpret<byte  , T>(Blend(H.Reinterpret<T, byte  >(x), H.Reinterpret<T, byte  >(y), mask)),
             sizeof(ushort) => H.Reinterpret<ushort, T>(Blend(H.Reinterpret<T, ushort>(x), H.Reinterpret<T, ushort>(y), mask)),

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._Vector.Gather.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._Vector.Gather.cs
@@ -272,11 +272,11 @@ partial class VectorOp
     {
         if (IntPtr.Size == 8)
         {
-            return H.Reinterpret<ulong, nuint>(GatherUnsafe((ulong*)ptr, H.Reinterpret<nint, long>(index)));
+            return H.BitCastV<ulong, nuint>(GatherUnsafe((ulong*)ptr, H.BitCastV<nint, long>(index)));
         }
         else if (IntPtr.Size == 4)
         {
-            return H.Reinterpret<uint, nuint>(GatherUnsafe((uint*)ptr, H.Reinterpret<nint, int>(index)));
+            return H.BitCastV<uint, nuint>(GatherUnsafe((uint*)ptr, H.BitCastV<nint, int>(index)));
         }
         throw new NotSupportedException();
     }
@@ -292,11 +292,11 @@ partial class VectorOp
     {
         if(IntPtr.Size == 8)
         {
-            return H.Reinterpret<ulong, nint>(GatherUnsafe((ulong*)ptr, H.Reinterpret<nint, long>(index)));
+            return H.BitCastV<ulong, nint>(GatherUnsafe((ulong*)ptr, H.BitCastV<nint, long>(index)));
         }
         else if(IntPtr.Size == 4)
         {
-            return H.Reinterpret<uint, nint>(GatherUnsafe((uint*)ptr, H.Reinterpret<nint, int>(index)));
+            return H.BitCastV<uint, nint>(GatherUnsafe((uint*)ptr, H.BitCastV<nint, int>(index)));
         }
         throw new NotSupportedException();
     }
@@ -311,7 +311,7 @@ partial class VectorOp
     public static unsafe Vector<nuint> Gather(ReadOnlySpan<nuint> table, Vector<nint> index)
     {
         var length = new Vector<nuint>((nuint)table.Length);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<nint, nuint>(index), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<nint, nuint>(index), length), Gather_.IndexRangeError);
         fixed (nuint* ptr = table)
         {
             return GatherUnsafe(ptr, index);
@@ -328,7 +328,7 @@ partial class VectorOp
     public static unsafe Vector<nint> Gather(ReadOnlySpan<nint> table, Vector<nint> index)
     {
         var length = new Vector<nuint>((nuint)table.Length);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<nint, nuint>(index), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<nint, nuint>(index), length), Gather_.IndexRangeError);
         fixed (nint* ptr = table)
         {
             return GatherUnsafe(ptr, index);

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._Vector.Gather.g.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._Vector.Gather.g.cs
@@ -32,7 +32,7 @@ partial class VectorOp
     /// <remarks> Note that this method will not validate buffer index. </remarks>
     [GeneratedCode("T4", null)]
     public static unsafe Vector<sbyte> GatherUnsafe(sbyte* ptr, Vector<int> index0, Vector<int> index1, Vector<int> index2, Vector<int> index3)
-        => H.Reinterpret<byte, sbyte>(GatherUnsafe((byte*)ptr, index0, index1, index2, index3));
+        => H.BitCastV<byte, sbyte>(GatherUnsafe((byte*)ptr, index0, index1, index2, index3));
 
     /// <summary> Looks up the table. </summary>
     /// <param name="ptr"></param>
@@ -42,7 +42,7 @@ partial class VectorOp
     /// <remarks> Note that this method will not validate buffer index. </remarks>
     [GeneratedCode("T4", null)]
     public static unsafe Vector<short> GatherUnsafe(short* ptr, Vector<int> indexLo, Vector<int> indexHi)
-        => H.Reinterpret<ushort, short>(GatherUnsafe((ushort*)ptr, indexLo, indexHi));
+        => H.BitCastV<ushort, short>(GatherUnsafe((ushort*)ptr, indexLo, indexHi));
 
     /// <summary> Looks up the table. </summary>
     /// <param name="ptr"></param>
@@ -51,7 +51,7 @@ partial class VectorOp
     /// <remarks> Note that this method will not validate buffer index. </remarks>
     [GeneratedCode("T4", null)]
     public static unsafe Vector<int> GatherUnsafe(int* ptr, Vector<int> index)
-        => H.Reinterpret<uint, int>(GatherUnsafe((uint*)ptr, index));
+        => H.BitCastV<uint, int>(GatherUnsafe((uint*)ptr, index));
 
     /// <summary> Looks up the table. </summary>
     /// <param name="ptr"></param>
@@ -60,7 +60,7 @@ partial class VectorOp
     /// <remarks> Note that this method will not validate buffer index. </remarks>
     [GeneratedCode("T4", null)]
     public static unsafe Vector<float> GatherUnsafe(float* ptr, Vector<int> index)
-        => H.Reinterpret<uint, float>(GatherUnsafe((uint*)ptr, index));
+        => H.BitCastV<uint, float>(GatherUnsafe((uint*)ptr, index));
 
     /// <summary> Looks up the table. </summary>
     /// <param name="ptr"></param>
@@ -69,7 +69,7 @@ partial class VectorOp
     /// <remarks> Note that this method will not validate buffer index. </remarks>
     [GeneratedCode("T4", null)]
     public static unsafe Vector<long> GatherUnsafe(long* ptr, Vector<long> index)
-        => H.Reinterpret<ulong, long>(GatherUnsafe((ulong*)ptr, index));
+        => H.BitCastV<ulong, long>(GatherUnsafe((ulong*)ptr, index));
 
     /// <summary> Looks up the table. </summary>
     /// <param name="ptr"></param>
@@ -78,7 +78,7 @@ partial class VectorOp
     /// <remarks> Note that this method will not validate buffer index. </remarks>
     [GeneratedCode("T4", null)]
     public static unsafe Vector<double> GatherUnsafe(double* ptr, Vector<long> index)
-        => H.Reinterpret<ulong, double>(GatherUnsafe((ulong*)ptr, index));
+        => H.BitCastV<ulong, double>(GatherUnsafe((ulong*)ptr, index));
 
     /// <summary> Looks up the table. </summary>
     /// <param name="table"></param>
@@ -92,10 +92,10 @@ partial class VectorOp
     public static unsafe Vector<byte> Gather(ReadOnlySpan<byte> table, Vector<int> index0, Vector<int> index1, Vector<int> index2, Vector<int> index3)
     {
         var length = new Vector<uint>((uint)table.Length);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<int, uint>(index0), length), Gather_.IndexRangeError);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<int, uint>(index1), length), Gather_.IndexRangeError);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<int, uint>(index2), length), Gather_.IndexRangeError);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<int, uint>(index3), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<int, uint>(index0), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<int, uint>(index1), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<int, uint>(index2), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<int, uint>(index3), length), Gather_.IndexRangeError);
         fixed (byte* ptr = table)
         {
             return GatherUnsafe(ptr, index0, index1, index2, index3);
@@ -114,10 +114,10 @@ partial class VectorOp
     public static unsafe Vector<sbyte> Gather(ReadOnlySpan<sbyte> table, Vector<int> index0, Vector<int> index1, Vector<int> index2, Vector<int> index3)
     {
         var length = new Vector<uint>((uint)table.Length);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<int, uint>(index0), length), Gather_.IndexRangeError);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<int, uint>(index1), length), Gather_.IndexRangeError);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<int, uint>(index2), length), Gather_.IndexRangeError);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<int, uint>(index3), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<int, uint>(index0), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<int, uint>(index1), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<int, uint>(index2), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<int, uint>(index3), length), Gather_.IndexRangeError);
         fixed (sbyte* ptr = table)
         {
             return GatherUnsafe(ptr, index0, index1, index2, index3);
@@ -134,8 +134,8 @@ partial class VectorOp
     public static unsafe Vector<ushort> Gather(ReadOnlySpan<ushort> table, Vector<int> indexLo, Vector<int> indexHi)
     {
         var length = new Vector<uint>((uint)table.Length);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<int, uint>(indexLo), length), Gather_.IndexRangeError);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<int, uint>(indexHi), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<int, uint>(indexLo), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<int, uint>(indexHi), length), Gather_.IndexRangeError);
         fixed (ushort* ptr = table)
         {
             return GatherUnsafe(ptr, indexLo, indexHi);
@@ -152,8 +152,8 @@ partial class VectorOp
     public static unsafe Vector<short> Gather(ReadOnlySpan<short> table, Vector<int> indexLo, Vector<int> indexHi)
     {
         var length = new Vector<uint>((uint)table.Length);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<int, uint>(indexLo), length), Gather_.IndexRangeError);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<int, uint>(indexHi), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<int, uint>(indexLo), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<int, uint>(indexHi), length), Gather_.IndexRangeError);
         fixed (short* ptr = table)
         {
             return GatherUnsafe(ptr, indexLo, indexHi);
@@ -169,7 +169,7 @@ partial class VectorOp
     public static unsafe Vector<uint> Gather(ReadOnlySpan<uint> table, Vector<int> index)
     {
         var length = new Vector<uint>((uint)table.Length);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<int, uint>(index), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<int, uint>(index), length), Gather_.IndexRangeError);
         fixed (uint* ptr = table)
         {
             return GatherUnsafe(ptr, index);
@@ -185,7 +185,7 @@ partial class VectorOp
     public static unsafe Vector<int> Gather(ReadOnlySpan<int> table, Vector<int> index)
     {
         var length = new Vector<uint>((uint)table.Length);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<int, uint>(index), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<int, uint>(index), length), Gather_.IndexRangeError);
         fixed (int* ptr = table)
         {
             return GatherUnsafe(ptr, index);
@@ -201,7 +201,7 @@ partial class VectorOp
     public static unsafe Vector<float> Gather(ReadOnlySpan<float> table, Vector<int> index)
     {
         var length = new Vector<uint>((uint)table.Length);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<int, uint>(index), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<int, uint>(index), length), Gather_.IndexRangeError);
         fixed (float* ptr = table)
         {
             return GatherUnsafe(ptr, index);
@@ -217,7 +217,7 @@ partial class VectorOp
     public static unsafe Vector<ulong> Gather(ReadOnlySpan<ulong> table, Vector<long> index)
     {
         var length = new Vector<ulong>((ulong)table.Length);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<long, ulong>(index), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<long, ulong>(index), length), Gather_.IndexRangeError);
         fixed (ulong* ptr = table)
         {
             return GatherUnsafe(ptr, index);
@@ -233,7 +233,7 @@ partial class VectorOp
     public static unsafe Vector<long> Gather(ReadOnlySpan<long> table, Vector<long> index)
     {
         var length = new Vector<ulong>((ulong)table.Length);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<long, ulong>(index), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<long, ulong>(index), length), Gather_.IndexRangeError);
         fixed (long* ptr = table)
         {
             return GatherUnsafe(ptr, index);
@@ -249,7 +249,7 @@ partial class VectorOp
     public static unsafe Vector<double> Gather(ReadOnlySpan<double> table, Vector<long> index)
     {
         var length = new Vector<ulong>((ulong)table.Length);
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<long, ulong>(index), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<long, ulong>(index), length), Gather_.IndexRangeError);
         fixed (double* ptr = table)
         {
             return GatherUnsafe(ptr, index);

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._Vector.Gather.tt
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._Vector.Gather.tt
@@ -56,7 +56,7 @@ partial class VectorOp
     /// <remarks> Note that this method will not validate buffer index. </remarks>
     [GeneratedCode("T4", null)]
     public static unsafe Vector<<#=def.ApiType#>> GatherUnsafe(<#=def.ApiType#>* ptr, <#=string.Join(", ", def.IndexArgs.Select(index => $"Vector<{def.IndexArgType}> {index}"))#>)
-        => H.Reinterpret<<#=def.InternalType#>, <#=def.ApiType#>>(GatherUnsafe((<#=def.InternalType#>*)ptr, <#=string.Join(", ", def.IndexArgs)#>));
+        => H.BitCastV<<#=def.InternalType#>, <#=def.ApiType#>>(GatherUnsafe((<#=def.InternalType#>*)ptr, <#=string.Join(", ", def.IndexArgs)#>));
 
 <#  } #>
 <#  foreach(var def in definitions) { #>
@@ -72,7 +72,7 @@ partial class VectorOp
     {
         var length = new Vector<u<#=def.IndexArgType#>>((u<#=def.IndexArgType#>)table.Length);
 <#      foreach(var index in def.IndexArgs) { #>
-        Guard.ValidArgument(LessThanAll(H.Reinterpret<<#=def.IndexArgType#>, u<#=def.IndexArgType#>>(<#=index#>), length), Gather_.IndexRangeError);
+        Guard.ValidArgument(LessThanAll(H.BitCastV<<#=def.IndexArgType#>, u<#=def.IndexArgType#>>(<#=index#>), length), Gather_.IndexRangeError);
 <#      } #>
         fixed (<#=def.ApiType#>* ptr = table)
         {

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._Vector.Permute4.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._Vector.Permute4.cs
@@ -115,8 +115,8 @@ partial class VectorOp
             retval[1] = input[(m1 & 0b10) >> 1][m1 & 0b01];
             retval[2] = input[(m2 & 0b10) >> 1][m2 & 0b01];
             retval[3] = input[(m3 & 0b10) >> 1][m3 & 0b01];
-            v1 = H.Reinterpret<T, Vector<T>>(retval[0]);
-            v2 = H.Reinterpret<T, Vector<T>>(retval[1]);
+            v1 = H.BitCast<T, Vector<T>>(retval[0]);
+            v2 = H.BitCast<T, Vector<T>>(retval[1]);
             return;
         }
         throw new NotSupportedException();

--- a/src/SmartVectorDotNet/VectorOp/VectorOp._Vector.Permute_Internal.cs
+++ b/src/SmartVectorDotNet/VectorOp/VectorOp._Vector.Permute_Internal.cs
@@ -53,13 +53,13 @@ partial class VectorOp
     /// <remarks> <c>m0, m1</c> must be <c>0 or 1</c>. </remarks>
     internal static Vector128<T> Permute2<T>(Vector128<T> v, byte m0, byte m1)
         where T : unmanaged
-        => Unsafe.SizeOf<T>() switch
+        => H.SizeOf<T>() switch
         {
 #pragma warning disable format
-            sizeof(byte  ) => H.Reinterpret<byte  , T>(PermuteX(H.Reinterpret<T, byte  >(v), m0, m1, m0, m1, Permute_.MaskBaseUInt8_Permute2)),
-            sizeof(ushort) => H.Reinterpret<ushort, T>(Permute4(H.Reinterpret<T, ushort>(v), m0, m1, (byte)(0b10 | m0), (byte)(0b10 | m1))),
-            sizeof(uint  ) => H.Reinterpret<uint  , T>(Permute4(H.Reinterpret<T, uint  >(v), m0, m1, (byte)(0b10 | m0), (byte)(0b10 | m1))),
-            sizeof(ulong ) => H.Reinterpret<ulong , T>(Permute4(H.Reinterpret<T, ulong >(v), m0, m1, (byte)(0b10 | m0), (byte)(0b10 | m1))),
+            sizeof(byte  ) => H.BitCast<byte  , T>(PermuteX(H.BitCast<T, byte  >(v), m0, m1, m0, m1, Permute_.MaskBaseUInt8_Permute2)),
+            sizeof(ushort) => H.BitCast<ushort, T>(Permute4(H.BitCast<T, ushort>(v), m0, m1, (byte)(0b10 | m0), (byte)(0b10 | m1))),
+            sizeof(uint  ) => H.BitCast<uint  , T>(Permute4(H.BitCast<T, uint  >(v), m0, m1, (byte)(0b10 | m0), (byte)(0b10 | m1))),
+            sizeof(ulong ) => H.BitCast<ulong , T>(Permute4(H.BitCast<T, ulong >(v), m0, m1, (byte)(0b10 | m0), (byte)(0b10 | m1))),
 #pragma warning restore format
             _ => throw new NotSupportedException(),
         };
@@ -67,13 +67,13 @@ partial class VectorOp
     /// <remarks> <c>m0, m1, m2, m3</c> must be <c>0, 1, 2, or 3</c>. </remarks>
     internal static Vector128<T> Permute4<T>(Vector128<T> v, byte m0, byte m1, byte m2, byte m3)
         where T : unmanaged
-        => Unsafe.SizeOf<T>() switch
+        => H.SizeOf<T>() switch
         {
 #pragma warning disable format
-            sizeof(byte  ) => H.Reinterpret<byte  , T>(PermuteX(H.Reinterpret<T, byte  >(v), m0, m1, m2, m3, Permute_.MaskBaseUInt8_Permute4)),
-            sizeof(ushort) => H.Reinterpret<ushort, T>(Permute4(H.Reinterpret<T, ushort>(v), m0, m1, m2, m3)),
-            sizeof(uint  ) => H.Reinterpret<uint  , T>(Permute4(H.Reinterpret<T, uint  >(v), m0, m1, m2, m3)),
-            sizeof(ulong ) => H.Reinterpret<ulong , T>(Permute4(H.Reinterpret<T, ulong >(v), m0, m1, m2, m3)),
+            sizeof(byte  ) => H.BitCast<byte  , T>(PermuteX(H.BitCast<T, byte  >(v), m0, m1, m2, m3, Permute_.MaskBaseUInt8_Permute4)),
+            sizeof(ushort) => H.BitCast<ushort, T>(Permute4(H.BitCast<T, ushort>(v), m0, m1, m2, m3)),
+            sizeof(uint  ) => H.BitCast<uint  , T>(Permute4(H.BitCast<T, uint  >(v), m0, m1, m2, m3)),
+            sizeof(ulong ) => H.BitCast<ulong , T>(Permute4(H.BitCast<T, ulong >(v), m0, m1, m2, m3)),
 #pragma warning restore format
             _ => throw new NotSupportedException(),
         };
@@ -85,7 +85,10 @@ partial class VectorOp
         if (Sse3.IsSupported)
         {
             var maskBytes = (stackalloc byte[Vector128<byte>.Count]);
-            MemoryMarshal.Cast<byte, uint>(maskBytes).Fill(MemoryMarshal.Cast<byte, uint>(maskOffsets)[0]);
+            unsafe
+            {
+                MemoryMarshal.Cast<byte, uint>(maskBytes).Fill(MemoryMarshal.Cast<byte, uint>(maskOffsets)[0]);
+            }
             var mask = Sse2.Add(
                 H.CreateVector128(maskBase),
                 H.CreateVector128(maskBytes));
@@ -107,7 +110,7 @@ partial class VectorOp
     {
         if (Sse2.IsSupported)
         {
-            ref readonly var vv = ref H.Reinterpret<ushort, byte>(in v);
+            var vv = H.BitCast<ushort, byte>(v);
             m0 <<= 1;
             m1 <<= 1;
             m2 <<= 1;
@@ -117,7 +120,7 @@ partial class VectorOp
                 m0, m0, m1, m1, m2, m2, m3, m3,
             });
             mask = Sse2.Add(mask, Permute_.Permute4Mask128);
-            return H.Reinterpret<byte, ushort>(Ssse3.Shuffle(vv, mask));
+            return H.BitCast<byte, ushort>(Ssse3.Shuffle(vv, mask));
         }
         else
         {
@@ -138,7 +141,7 @@ partial class VectorOp
     {
         if (Sse2.IsSupported)
         {
-            ref readonly var vv = ref H.Reinterpret<uint, float>(in v);
+            var vv = H.BitCast<uint, float>(v);
             var control = H.CreateVector128(stackalloc int[] { m0, m1, m2, m3, });
             return Vector128.As<float, uint>(Avx.PermuteVar(vv, control));
         }
@@ -165,13 +168,13 @@ partial class VectorOp
     /// <remarks> <c>m0, m1</c> must be <c>0 or 1</c>. </remarks>
     internal static Vector256<T> Permute2<T>(Vector256<T> v, byte m0, byte m1)
         where T : unmanaged
-        => Unsafe.SizeOf<T>() switch
+        => H.SizeOf<T>() switch
         {
 #pragma warning disable format
-            sizeof(byte  ) => H.Reinterpret<byte  , T>(Permute4(H.Reinterpret<T, byte  >(v), m0, m1, (byte)(0b10 | m0), (byte)(0b10 | m1))),
-            sizeof(ushort) => H.Reinterpret<ushort, T>(Permute4(H.Reinterpret<T, ushort>(v), m0, m1, (byte)(0b10 | m0), (byte)(0b10 | m1))),
-            sizeof(uint  ) => H.Reinterpret<uint  , T>(Permute4(H.Reinterpret<T, uint  >(v), m0, m1, (byte)(0b10 | m0), (byte)(0b10 | m1))),
-            sizeof(ulong ) => H.Reinterpret<ulong , T>(Permute4(H.Reinterpret<T, ulong >(v), m0, m1, (byte)(0b10 | m0), (byte)(0b10 | m1))),
+            sizeof(byte  ) => H.BitCast<byte  , T>(Permute4(H.BitCast<T, byte  >(v), m0, m1, (byte)(0b10 | m0), (byte)(0b10 | m1))),
+            sizeof(ushort) => H.BitCast<ushort, T>(Permute4(H.BitCast<T, ushort>(v), m0, m1, (byte)(0b10 | m0), (byte)(0b10 | m1))),
+            sizeof(uint  ) => H.BitCast<uint  , T>(Permute4(H.BitCast<T, uint  >(v), m0, m1, (byte)(0b10 | m0), (byte)(0b10 | m1))),
+            sizeof(ulong ) => H.BitCast<ulong , T>(Permute4(H.BitCast<T, ulong >(v), m0, m1, (byte)(0b10 | m0), (byte)(0b10 | m1))),
 #pragma warning restore format
             _ => throw new NotSupportedException(),
         };
@@ -179,13 +182,13 @@ partial class VectorOp
     /// <remarks> <c>m0, m1, m2, m3</c> must be <c>0, 1, 2, or 3</c>. </remarks>
     internal static Vector256<T> Permute4<T>(Vector256<T> v, byte m0, byte m1, byte m2, byte m3)
         where T : unmanaged
-        => Unsafe.SizeOf<T>() switch
+        => H.SizeOf<T>() switch
         {
 #pragma warning disable format
-            sizeof(byte  ) => H.Reinterpret<byte  , T>(PermuteX(H.Reinterpret<T, byte  >(v), m0, m1, m2, m3, Permute_.MaskBaseUInt8_Permute4)),
-            sizeof(ushort) => H.Reinterpret<ushort, T>(Permute4(H.Reinterpret<T, ushort>(v), m0, m1, m2, m3)),
-            sizeof(uint  ) => H.Reinterpret<uint  , T>(Permute4(H.Reinterpret<T, uint  >(v), m0, m1, m2, m3)),
-            sizeof(ulong ) => H.Reinterpret<ulong , T>(Permute4(H.Reinterpret<T, ulong >(v), m0, m1, m2, m3)),
+            sizeof(byte  ) => H.BitCast<byte  , T>(PermuteX(H.BitCast<T, byte  >(v), m0, m1, m2, m3, Permute_.MaskBaseUInt8_Permute4)),
+            sizeof(ushort) => H.BitCast<ushort, T>(Permute4(H.BitCast<T, ushort>(v), m0, m1, m2, m3)),
+            sizeof(uint  ) => H.BitCast<uint  , T>(Permute4(H.BitCast<T, uint  >(v), m0, m1, m2, m3)),
+            sizeof(ulong ) => H.BitCast<ulong , T>(Permute4(H.BitCast<T, ulong >(v), m0, m1, m2, m3)),
 #pragma warning restore format
             _ => throw new NotSupportedException(),
         };
@@ -197,7 +200,10 @@ partial class VectorOp
         if (Avx2.IsSupported)
         {
             var maskBytes = (stackalloc byte[Vector256<byte>.Count]);
-            MemoryMarshal.Cast<byte, uint>(maskBytes).Fill(MemoryMarshal.Cast<byte, uint>(maskOffsets)[0]);
+            unsafe
+            {
+                MemoryMarshal.Cast<byte, uint>(maskBytes).Fill(MemoryMarshal.Cast<byte, uint>(maskOffsets)[0]);
+            }
             var mask = Avx2.Add(
                 H.CreateVector256(maskBase),
                 H.CreateVector256(maskBytes));
@@ -219,7 +225,7 @@ partial class VectorOp
     {
         if (Avx2.IsSupported)
         {
-            ref readonly var vv = ref H.Reinterpret<ushort, byte>(in v);
+            var vv = H.BitCast<ushort, byte>(v);
             m0 <<= 1;
             m1 <<= 1;
             m2 <<= 1;
@@ -231,7 +237,7 @@ partial class VectorOp
                 m0, m0, m1, m1, m2, m2, m3, m3,
             });
             mask = Avx2.Add(mask, Permute_.Permute4Mask256);
-            return H.Reinterpret<byte, ushort>(Avx2.Shuffle(vv, mask));
+            return H.BitCast<byte, ushort>(Avx2.Shuffle(vv, mask));
         }
         else
         {
@@ -252,7 +258,7 @@ partial class VectorOp
     {
         if (Avx2.IsSupported)
         {
-            ref readonly var vv = ref H.Reinterpret<uint, float>(in v);
+            var vv = H.BitCast<uint, float>(v);
             var control = H.CreateVector256(stackalloc int[] { m0, m1, m2, m3, m0 + 4, m1 + 4, m2 + 4, m3 + 4, });
             return Vector256.As<float, uint>(Avx.PermuteVar(vv, control));
         }
@@ -275,7 +281,7 @@ partial class VectorOp
     {
         if (Avx2.IsSupported)
         {
-            ref readonly var vv = ref H.Reinterpret<ulong, float>(in v);
+            var vv = H.BitCast<ulong, float>(v);
             m0 <<= 1;
             m1 <<= 1;
             m2 <<= 1;

--- a/src/SmartVectorDotNet/Vectorization/Vectorization._Binary.g.cs
+++ b/src/SmartVectorDotNet/Vectorization/Vectorization._Binary.g.cs
@@ -27,7 +27,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        AddCore(x, y, ans);
+        unsafe
+        {
+            AddCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -45,7 +48,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        AddCore(x, y, ans);
+        unsafe
+        {
+            AddCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -65,7 +71,10 @@ partial class Vectorization
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        AddCore(x, y, ans);
+        unsafe
+        {
+            AddCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -84,7 +93,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void AddCore<T>(T x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -108,7 +117,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void AddCore<T>(ReadOnlySpan<T> x, T y, Span<T> ans)
         where T : unmanaged
     {
@@ -132,7 +141,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void AddCore<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -246,7 +255,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        SubtractCore(x, y, ans);
+        unsafe
+        {
+            SubtractCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -264,7 +276,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        SubtractCore(x, y, ans);
+        unsafe
+        {
+            SubtractCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -284,7 +299,10 @@ partial class Vectorization
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        SubtractCore(x, y, ans);
+        unsafe
+        {
+            SubtractCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -303,7 +321,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void SubtractCore<T>(T x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -327,7 +345,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void SubtractCore<T>(ReadOnlySpan<T> x, T y, Span<T> ans)
         where T : unmanaged
     {
@@ -351,7 +369,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void SubtractCore<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -465,7 +483,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        MultiplyCore(x, y, ans);
+        unsafe
+        {
+            MultiplyCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -483,7 +504,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        MultiplyCore(x, y, ans);
+        unsafe
+        {
+            MultiplyCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -503,7 +527,10 @@ partial class Vectorization
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        MultiplyCore(x, y, ans);
+        unsafe
+        {
+            MultiplyCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -522,7 +549,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void MultiplyCore<T>(T x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -546,7 +573,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void MultiplyCore<T>(ReadOnlySpan<T> x, T y, Span<T> ans)
         where T : unmanaged
     {
@@ -570,7 +597,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void MultiplyCore<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -684,7 +711,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        DivideCore(x, y, ans);
+        unsafe
+        {
+            DivideCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -702,7 +732,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        DivideCore(x, y, ans);
+        unsafe
+        {
+            DivideCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -722,7 +755,10 @@ partial class Vectorization
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        DivideCore(x, y, ans);
+        unsafe
+        {
+            DivideCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -741,7 +777,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void DivideCore<T>(T x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -765,7 +801,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void DivideCore<T>(ReadOnlySpan<T> x, T y, Span<T> ans)
         where T : unmanaged
     {
@@ -789,7 +825,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void DivideCore<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -903,7 +939,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        ModuloCore(x, y, ans);
+        unsafe
+        {
+            ModuloCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -921,7 +960,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        ModuloCore(x, y, ans);
+        unsafe
+        {
+            ModuloCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -941,7 +983,10 @@ partial class Vectorization
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        ModuloCore(x, y, ans);
+        unsafe
+        {
+            ModuloCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -960,7 +1005,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void ModuloCore<T>(T x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -984,7 +1029,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void ModuloCore<T>(ReadOnlySpan<T> x, T y, Span<T> ans)
         where T : unmanaged
     {
@@ -1008,7 +1053,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void ModuloCore<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -1122,7 +1167,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        ModuloByFloorCore(x, y, ans);
+        unsafe
+        {
+            ModuloByFloorCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -1140,7 +1188,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        ModuloByFloorCore(x, y, ans);
+        unsafe
+        {
+            ModuloByFloorCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -1160,7 +1211,10 @@ partial class Vectorization
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        ModuloByFloorCore(x, y, ans);
+        unsafe
+        {
+            ModuloByFloorCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -1179,7 +1233,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void ModuloByFloorCore<T>(T x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -1203,7 +1257,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void ModuloByFloorCore<T>(ReadOnlySpan<T> x, T y, Span<T> ans)
         where T : unmanaged
     {
@@ -1227,7 +1281,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void ModuloByFloorCore<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -1341,7 +1395,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        AddSaturateCore(x, y, ans);
+        unsafe
+        {
+            AddSaturateCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -1359,7 +1416,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        AddSaturateCore(x, y, ans);
+        unsafe
+        {
+            AddSaturateCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -1379,7 +1439,10 @@ partial class Vectorization
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        AddSaturateCore(x, y, ans);
+        unsafe
+        {
+            AddSaturateCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -1398,7 +1461,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void AddSaturateCore<T>(T x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -1422,7 +1485,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void AddSaturateCore<T>(ReadOnlySpan<T> x, T y, Span<T> ans)
         where T : unmanaged
     {
@@ -1446,7 +1509,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void AddSaturateCore<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -1560,7 +1623,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        SubtractSaturateCore(x, y, ans);
+        unsafe
+        {
+            SubtractSaturateCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -1578,7 +1644,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        SubtractSaturateCore(x, y, ans);
+        unsafe
+        {
+            SubtractSaturateCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -1598,7 +1667,10 @@ partial class Vectorization
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        SubtractSaturateCore(x, y, ans);
+        unsafe
+        {
+            SubtractSaturateCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -1617,7 +1689,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void SubtractSaturateCore<T>(T x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -1641,7 +1713,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void SubtractSaturateCore<T>(ReadOnlySpan<T> x, T y, Span<T> ans)
         where T : unmanaged
     {
@@ -1665,7 +1737,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void SubtractSaturateCore<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -1779,7 +1851,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        BitwiseAndCore(x, y, ans);
+        unsafe
+        {
+            BitwiseAndCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -1797,7 +1872,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        BitwiseAndCore(x, y, ans);
+        unsafe
+        {
+            BitwiseAndCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -1817,7 +1895,10 @@ partial class Vectorization
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        BitwiseAndCore(x, y, ans);
+        unsafe
+        {
+            BitwiseAndCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -1836,7 +1917,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void BitwiseAndCore<T>(T x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -1860,7 +1941,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void BitwiseAndCore<T>(ReadOnlySpan<T> x, T y, Span<T> ans)
         where T : unmanaged
     {
@@ -1884,7 +1965,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void BitwiseAndCore<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -1998,7 +2079,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        BitwiseOrCore(x, y, ans);
+        unsafe
+        {
+            BitwiseOrCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -2016,7 +2100,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        BitwiseOrCore(x, y, ans);
+        unsafe
+        {
+            BitwiseOrCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -2036,7 +2123,10 @@ partial class Vectorization
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        BitwiseOrCore(x, y, ans);
+        unsafe
+        {
+            BitwiseOrCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -2055,7 +2145,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void BitwiseOrCore<T>(T x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -2079,7 +2169,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void BitwiseOrCore<T>(ReadOnlySpan<T> x, T y, Span<T> ans)
         where T : unmanaged
     {
@@ -2103,7 +2193,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void BitwiseOrCore<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -2217,7 +2307,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        BitwiseXorCore(x, y, ans);
+        unsafe
+        {
+            BitwiseXorCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -2235,7 +2328,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        BitwiseXorCore(x, y, ans);
+        unsafe
+        {
+            BitwiseXorCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -2255,7 +2351,10 @@ partial class Vectorization
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        BitwiseXorCore(x, y, ans);
+        unsafe
+        {
+            BitwiseXorCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -2274,7 +2373,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void BitwiseXorCore<T>(T x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -2298,7 +2397,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void BitwiseXorCore<T>(ReadOnlySpan<T> x, T y, Span<T> ans)
         where T : unmanaged
     {
@@ -2322,7 +2421,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void BitwiseXorCore<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -2436,7 +2535,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        EqualsCore(x, y, ans);
+        unsafe
+        {
+            EqualsCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -2454,7 +2556,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        EqualsCore(x, y, ans);
+        unsafe
+        {
+            EqualsCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -2474,7 +2579,10 @@ partial class Vectorization
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        EqualsCore(x, y, ans);
+        unsafe
+        {
+            EqualsCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -2493,7 +2601,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void EqualsCore<T>(T x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -2517,7 +2625,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void EqualsCore<T>(ReadOnlySpan<T> x, T y, Span<T> ans)
         where T : unmanaged
     {
@@ -2541,7 +2649,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void EqualsCore<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -2655,7 +2763,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        LessThanCore(x, y, ans);
+        unsafe
+        {
+            LessThanCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -2673,7 +2784,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        LessThanCore(x, y, ans);
+        unsafe
+        {
+            LessThanCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -2693,7 +2807,10 @@ partial class Vectorization
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        LessThanCore(x, y, ans);
+        unsafe
+        {
+            LessThanCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -2712,7 +2829,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void LessThanCore<T>(T x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -2736,7 +2853,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void LessThanCore<T>(ReadOnlySpan<T> x, T y, Span<T> ans)
         where T : unmanaged
     {
@@ -2760,7 +2877,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void LessThanCore<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -2874,7 +2991,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        LessThanOrEqualCore(x, y, ans);
+        unsafe
+        {
+            LessThanOrEqualCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -2892,7 +3012,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        LessThanOrEqualCore(x, y, ans);
+        unsafe
+        {
+            LessThanOrEqualCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -2912,7 +3035,10 @@ partial class Vectorization
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        LessThanOrEqualCore(x, y, ans);
+        unsafe
+        {
+            LessThanOrEqualCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -2931,7 +3057,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void LessThanOrEqualCore<T>(T x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -2955,7 +3081,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void LessThanOrEqualCore<T>(ReadOnlySpan<T> x, T y, Span<T> ans)
         where T : unmanaged
     {
@@ -2979,7 +3105,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void LessThanOrEqualCore<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -3093,7 +3219,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        GreaterThanCore(x, y, ans);
+        unsafe
+        {
+            GreaterThanCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -3111,7 +3240,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        GreaterThanCore(x, y, ans);
+        unsafe
+        {
+            GreaterThanCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -3131,7 +3263,10 @@ partial class Vectorization
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        GreaterThanCore(x, y, ans);
+        unsafe
+        {
+            GreaterThanCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -3150,7 +3285,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void GreaterThanCore<T>(T x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -3174,7 +3309,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void GreaterThanCore<T>(ReadOnlySpan<T> x, T y, Span<T> ans)
         where T : unmanaged
     {
@@ -3198,7 +3333,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void GreaterThanCore<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -3312,7 +3447,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        GreaterThanOrEqualCore(x, y, ans);
+        unsafe
+        {
+            GreaterThanOrEqualCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -3330,7 +3468,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        GreaterThanOrEqualCore(x, y, ans);
+        unsafe
+        {
+            GreaterThanOrEqualCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -3350,7 +3491,10 @@ partial class Vectorization
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
         using var safeYBuffer = EnsureSourceSafe(ref y, ans);
-        GreaterThanOrEqualCore(x, y, ans);
+        unsafe
+        {
+            GreaterThanOrEqualCore(x, y, ans);
+        }
     }
     
     /// <summary>
@@ -3369,7 +3513,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void GreaterThanOrEqualCore<T>(T x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -3393,7 +3537,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void GreaterThanOrEqualCore<T>(ReadOnlySpan<T> x, T y, Span<T> ans)
         where T : unmanaged
     {
@@ -3417,7 +3561,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void GreaterThanOrEqualCore<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> y, Span<T> ans)
         where T : unmanaged
     {
@@ -3531,7 +3675,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref x, ans);
-        Atan2Core(y, x, ans);
+        unsafe
+        {
+            Atan2Core(y, x, ans);
+        }
     }
     
     /// <summary>
@@ -3549,7 +3696,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(y.Length == ans.Length, "`y` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref y, ans);
-        Atan2Core(y, x, ans);
+        unsafe
+        {
+            Atan2Core(y, x, ans);
+        }
     }
     
     /// <summary>
@@ -3569,7 +3719,10 @@ partial class Vectorization
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref y, ans);
         using var safeYBuffer = EnsureSourceSafe(ref x, ans);
-        Atan2Core(y, x, ans);
+        unsafe
+        {
+            Atan2Core(y, x, ans);
+        }
     }
     
     /// <summary>
@@ -3588,7 +3741,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void Atan2Core<T>(T y, ReadOnlySpan<T> x, Span<T> ans)
         where T : unmanaged
     {
@@ -3612,7 +3765,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void Atan2Core<T>(ReadOnlySpan<T> y, T x, Span<T> ans)
         where T : unmanaged
     {
@@ -3636,7 +3789,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void Atan2Core<T>(ReadOnlySpan<T> y, ReadOnlySpan<T> x, Span<T> ans)
         where T : unmanaged
     {
@@ -3750,7 +3903,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(newBase.Length == ans.Length, "`newBase` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref newBase, ans);
-        LogCore(x, newBase, ans);
+        unsafe
+        {
+            LogCore(x, newBase, ans);
+        }
     }
     
     /// <summary>
@@ -3768,7 +3924,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        LogCore(x, newBase, ans);
+        unsafe
+        {
+            LogCore(x, newBase, ans);
+        }
     }
     
     /// <summary>
@@ -3788,7 +3947,10 @@ partial class Vectorization
         Guard.ValidArgument(newBase.Length == ans.Length, "`newBase` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
         using var safeYBuffer = EnsureSourceSafe(ref newBase, ans);
-        LogCore(x, newBase, ans);
+        unsafe
+        {
+            LogCore(x, newBase, ans);
+        }
     }
     
     /// <summary>
@@ -3807,7 +3969,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void LogCore<T>(T x, ReadOnlySpan<T> newBase, Span<T> ans)
         where T : unmanaged
     {
@@ -3831,7 +3993,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void LogCore<T>(ReadOnlySpan<T> x, T newBase, Span<T> ans)
         where T : unmanaged
     {
@@ -3855,7 +4017,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void LogCore<T>(ReadOnlySpan<T> x, ReadOnlySpan<T> newBase, Span<T> ans)
         where T : unmanaged
     {
@@ -3969,7 +4131,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref x, ans);
-        PowCore(a, x, ans);
+        unsafe
+        {
+            PowCore(a, x, ans);
+        }
     }
     
     /// <summary>
@@ -3987,7 +4152,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(a.Length == ans.Length, "`a` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref a, ans);
-        PowCore(a, x, ans);
+        unsafe
+        {
+            PowCore(a, x, ans);
+        }
     }
     
     /// <summary>
@@ -4007,7 +4175,10 @@ partial class Vectorization
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref a, ans);
         using var safeYBuffer = EnsureSourceSafe(ref x, ans);
-        PowCore(a, x, ans);
+        unsafe
+        {
+            PowCore(a, x, ans);
+        }
     }
     
     /// <summary>
@@ -4026,7 +4197,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void PowCore<T>(T a, ReadOnlySpan<T> x, Span<T> ans)
         where T : unmanaged
     {
@@ -4050,7 +4221,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void PowCore<T>(ReadOnlySpan<T> a, T x, Span<T> ans)
         where T : unmanaged
     {
@@ -4074,7 +4245,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void PowCore<T>(ReadOnlySpan<T> a, ReadOnlySpan<T> x, Span<T> ans)
         where T : unmanaged
     {

--- a/src/SmartVectorDotNet/Vectorization/Vectorization._Binary.tt
+++ b/src/SmartVectorDotNet/Vectorization/Vectorization._Binary.tt
@@ -57,7 +57,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(<#=arg2#>.Length == ans.Length, "`<#=arg2#>` and `ans` must have same length.");
         using var safeYBuffer = EnsureSourceSafe(ref <#=arg2#>, ans);
-        <#=methodName#>Core(<#=arg1#>, <#=arg2#>, ans);
+        unsafe
+        {
+            <#=methodName#>Core(<#=arg1#>, <#=arg2#>, ans);
+        }
     }
     
     <# DocumentPublic(methodName, arg1, arg2); #>
@@ -67,7 +70,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(<#=arg1#>.Length == ans.Length, "`<#=arg1#>` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref <#=arg1#>, ans);
-        <#=methodName#>Core(<#=arg1#>, <#=arg2#>, ans);
+        unsafe
+        {
+            <#=methodName#>Core(<#=arg1#>, <#=arg2#>, ans);
+        }
     }
     
     <# DocumentPublic(methodName, arg1, arg2); #>
@@ -79,11 +85,14 @@ partial class Vectorization
         Guard.ValidArgument(<#=arg2#>.Length == ans.Length, "`<#=arg2#>` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref <#=arg1#>, ans);
         using var safeYBuffer = EnsureSourceSafe(ref <#=arg2#>, ans);
-        <#=methodName#>Core(<#=arg1#>, <#=arg2#>, ans);
+        unsafe
+        {
+            <#=methodName#>Core(<#=arg1#>, <#=arg2#>, ans);
+        }
     }
     
     <# DocumentCore(methodName, $"{methodName}{{T}}(T, ReadOnlySpan{{T}}, Span{{T}})", arg1, arg2); #>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void <#=methodName#>Core<T>(T <#=arg1#>, ReadOnlySpan<T> <#=arg2#>, Span<T> ans)
         where T : unmanaged
     {
@@ -92,7 +101,7 @@ partial class Vectorization
     }
     
     <# DocumentCore(methodName, $"{methodName}{{T}}(ReadOnlySpan{{T}}, T, Span{{T}})", arg1, arg2); #>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void <#=methodName#>Core<T>(ReadOnlySpan<T> <#=arg1#>, T <#=arg2#>, Span<T> ans)
         where T : unmanaged
     {
@@ -101,7 +110,7 @@ partial class Vectorization
     }
     
     <# DocumentCore(methodName, $"{methodName}{{T}}(ReadOnlySpan{{T}}, ReadOnlySpan{{T}}, Span{{T}})", arg1, arg2); #>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void <#=methodName#>Core<T>(ReadOnlySpan<T> <#=arg1#>, ReadOnlySpan<T> <#=arg2#>, Span<T> ans)
         where T : unmanaged
     {

--- a/src/SmartVectorDotNet/Vectorization/Vectorization._Gather.cs
+++ b/src/SmartVectorDotNet/Vectorization/Vectorization._Gather.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace SmartVectorDotNet;
@@ -29,7 +27,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(indices.Length == dst.Length, "`indices` and `dst` must have same length.");
         using var safeTableBuffer = EnsureSourceSafe(ref table, dst);
-        GatherCore(table, indices, dst);
+        unsafe
+        {
+            GatherCore(table, indices, dst);
+        }
     }
 
     /// <summary> Looks up the table. </summary>
@@ -46,7 +47,8 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    protected virtual void GatherCore<T>(ReadOnlySpan<T> table, ReadOnlySpan<int> indices, Span<T> dst)
+    [UnsafeApi]
+    protected virtual unsafe void GatherCore<T>(ReadOnlySpan<T> table, ReadOnlySpan<int> indices, Span<T> dst)
         where T : unmanaged
     {
         for(var i = 0; i < dst.Length; ++i)
@@ -60,9 +62,9 @@ partial class Vectorization
 partial class SimdVectorization
 {
     /// <inheritdoc />
-    protected override void GatherCore<T>(ReadOnlySpan<T> table, ReadOnlySpan<int> indices, Span<T> dst)
+    protected override unsafe void GatherCore<T>(ReadOnlySpan<T> table, ReadOnlySpan<int> indices, Span<T> dst)
     {
-        switch(Unsafe.SizeOf<T>())
+        switch(H.SizeOf<T>())
         {
         case sizeof(byte):
             GatherCore1(MemoryMarshal.Cast<T, byte>(table), indices, MemoryMarshal.Cast<T, byte>(dst));
@@ -86,16 +88,16 @@ partial class SimdVectorization
     {
         var indexLimit = new Vector<uint>((uint)table.Length);
         var vdst = MemoryMarshal.Cast<byte, Vector<byte>>(dst);
-        var vindices = MemoryMarshal.Cast<int, Vector<int>>(indices).Slice(0, vdst.Length * 4);
+        var vindices = MemoryMarshal.Cast<int, Vector<int>>(indices)[..(vdst.Length * 4)];
         fixed (byte* ptr = table)
         {
             for (var i = 0; i < vdst.Length; ++i)
             {
                 var j = i * 4;
-                Guard.ValidArgument(OP.LessThanAll(H.Reinterpret<int, uint>(vindices[j + 0]), indexLimit), Gather_.IndexRangeError);
-                Guard.ValidArgument(OP.LessThanAll(H.Reinterpret<int, uint>(vindices[j + 1]), indexLimit), Gather_.IndexRangeError);
-                Guard.ValidArgument(OP.LessThanAll(H.Reinterpret<int, uint>(vindices[j + 2]), indexLimit), Gather_.IndexRangeError);
-                Guard.ValidArgument(OP.LessThanAll(H.Reinterpret<int, uint>(vindices[j + 3]), indexLimit), Gather_.IndexRangeError);
+                Guard.ValidArgument(OP.LessThanAll(H.BitCastV<int, uint>(vindices[j + 0]), indexLimit), Gather_.IndexRangeError);
+                Guard.ValidArgument(OP.LessThanAll(H.BitCastV<int, uint>(vindices[j + 1]), indexLimit), Gather_.IndexRangeError);
+                Guard.ValidArgument(OP.LessThanAll(H.BitCastV<int, uint>(vindices[j + 2]), indexLimit), Gather_.IndexRangeError);
+                Guard.ValidArgument(OP.LessThanAll(H.BitCastV<int, uint>(vindices[j + 3]), indexLimit), Gather_.IndexRangeError);
                 vdst[i] = OP.GatherUnsafe(ptr, vindices[j + 0], vindices[j + 1], vindices[j + 2], vindices[j + 3]);
             }
             for (var i = vdst.Length * Vector<byte>.Count; i < dst.Length; ++i)
@@ -110,14 +112,14 @@ partial class SimdVectorization
     {
         var indexLimit = new Vector<uint>((uint)table.Length);
         var vdst = MemoryMarshal.Cast<ushort, Vector<ushort>>(dst);
-        var vindices = MemoryMarshal.Cast<int, Vector<int>>(indices).Slice(0, vdst.Length * 2);
+        var vindices = MemoryMarshal.Cast<int, Vector<int>>(indices)[..(vdst.Length * 2)];
         fixed (ushort* ptr = table)
         {
             for (var i = 0; i < vdst.Length; ++i)
             {
                 var j = i * 2;
-                Guard.ValidArgument(OP.LessThanAll(H.Reinterpret<int, uint>(vindices[j + 0]), indexLimit), Gather_.IndexRangeError);
-                Guard.ValidArgument(OP.LessThanAll(H.Reinterpret<int, uint>(vindices[j + 1]), indexLimit), Gather_.IndexRangeError);
+                Guard.ValidArgument(OP.LessThanAll(H.BitCastV<int, uint>(vindices[j + 0]), indexLimit), Gather_.IndexRangeError);
+                Guard.ValidArgument(OP.LessThanAll(H.BitCastV<int, uint>(vindices[j + 1]), indexLimit), Gather_.IndexRangeError);
                 vdst[i] = OP.GatherUnsafe(ptr, vindices[j + 0], vindices[j + 1]);
             }
             for (var i = vdst.Length * Vector<ushort>.Count; i < dst.Length; ++i)
@@ -137,7 +139,7 @@ partial class SimdVectorization
         {
             for (var i = 0; i < vdst.Length; ++i)
             {
-                Guard.ValidArgument(OP.LessThanAll(H.Reinterpret<int, uint>(vindices[i]), indexLimit), Gather_.IndexRangeError);
+                Guard.ValidArgument(OP.LessThanAll(H.BitCastV<int, uint>(vindices[i]), indexLimit), Gather_.IndexRangeError);
                 vdst[i] = OP.GatherUnsafe(ptr, vindices[i]);
             }
             for (var i = vdst.Length * Vector<uint>.Count; i < dst.Length; ++i)
@@ -152,14 +154,14 @@ partial class SimdVectorization
     {
         var indexLimit = new Vector<ulong>((ulong)table.Length);
         var vindices = MemoryMarshal.Cast<int, Vector<int>>(indices);
-        var vdst = MemoryMarshal.Cast<ulong, Vector<ulong>>(dst).Slice(0, vindices.Length * 2);
+        var vdst = MemoryMarshal.Cast<ulong, Vector<ulong>>(dst)[..(vindices.Length * 2)];
         fixed (ulong* ptr = table)
         {
             for (var i = 0; i < vdst.Length; ++i)
             {
                 OP.Widen(vindices[i / 2], out var lo, out var hi);
                 var idx = (i & 1) == 0 ? lo : hi;
-                Guard.ValidArgument(OP.LessThanAll(H.Reinterpret<long, ulong>(idx), indexLimit), Gather_.IndexRangeError);
+                Guard.ValidArgument(OP.LessThanAll(H.BitCastV<long, ulong>(idx), indexLimit), Gather_.IndexRangeError);
                 vdst[i] = OP.GatherUnsafe(ptr, idx);
             }
             for (var i = vdst.Length * Vector<ulong>.Count; i < dst.Length; ++i)

--- a/src/SmartVectorDotNet/Vectorization/Vectorization._NarrowWiden.g.cs
+++ b/src/SmartVectorDotNet/Vectorization/Vectorization._NarrowWiden.g.cs
@@ -27,7 +27,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        NarrowCore(x, ans);
+        unsafe
+        {
+            NarrowCore(x, ans);
+        }
     }
     
     /// <summary>
@@ -43,8 +46,8 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
-    protected internal virtual void NarrowCore(ReadOnlySpan<ushort> x, Span<byte> ans)
+    [GeneratedCode("T4", null), UnsafeApi]
+    protected internal virtual unsafe void NarrowCore(ReadOnlySpan<ushort> x, Span<byte> ans)
     {
         for (var i = 0; i < ans.Length; ++i)
             ans[i] = (byte)x[i];
@@ -92,7 +95,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        NarrowCore(x, ans);
+        unsafe
+        {
+            NarrowCore(x, ans);
+        }
     }
     
     /// <summary>
@@ -108,8 +114,8 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
-    protected internal virtual void NarrowCore(ReadOnlySpan<uint> x, Span<ushort> ans)
+    [GeneratedCode("T4", null), UnsafeApi]
+    protected internal virtual unsafe void NarrowCore(ReadOnlySpan<uint> x, Span<ushort> ans)
     {
         for (var i = 0; i < ans.Length; ++i)
             ans[i] = (ushort)x[i];
@@ -157,7 +163,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        NarrowCore(x, ans);
+        unsafe
+        {
+            NarrowCore(x, ans);
+        }
     }
     
     /// <summary>
@@ -173,8 +182,8 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
-    protected internal virtual void NarrowCore(ReadOnlySpan<ulong> x, Span<uint> ans)
+    [GeneratedCode("T4", null), UnsafeApi]
+    protected internal virtual unsafe void NarrowCore(ReadOnlySpan<ulong> x, Span<uint> ans)
     {
         for (var i = 0; i < ans.Length; ++i)
             ans[i] = (uint)x[i];
@@ -222,7 +231,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        NarrowCore(x, ans);
+        unsafe
+        {
+            NarrowCore(x, ans);
+        }
     }
     
     /// <summary>
@@ -238,8 +250,8 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
-    protected internal virtual void NarrowCore(ReadOnlySpan<short> x, Span<sbyte> ans)
+    [GeneratedCode("T4", null), UnsafeApi]
+    protected internal virtual unsafe void NarrowCore(ReadOnlySpan<short> x, Span<sbyte> ans)
     {
         for (var i = 0; i < ans.Length; ++i)
             ans[i] = (sbyte)x[i];
@@ -287,7 +299,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        NarrowCore(x, ans);
+        unsafe
+        {
+            NarrowCore(x, ans);
+        }
     }
     
     /// <summary>
@@ -303,8 +318,8 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
-    protected internal virtual void NarrowCore(ReadOnlySpan<int> x, Span<short> ans)
+    [GeneratedCode("T4", null), UnsafeApi]
+    protected internal virtual unsafe void NarrowCore(ReadOnlySpan<int> x, Span<short> ans)
     {
         for (var i = 0; i < ans.Length; ++i)
             ans[i] = (short)x[i];
@@ -352,7 +367,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        NarrowCore(x, ans);
+        unsafe
+        {
+            NarrowCore(x, ans);
+        }
     }
     
     /// <summary>
@@ -368,8 +386,8 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
-    protected internal virtual void NarrowCore(ReadOnlySpan<long> x, Span<int> ans)
+    [GeneratedCode("T4", null), UnsafeApi]
+    protected internal virtual unsafe void NarrowCore(ReadOnlySpan<long> x, Span<int> ans)
     {
         for (var i = 0; i < ans.Length; ++i)
             ans[i] = (int)x[i];
@@ -413,11 +431,15 @@ partial class Vectorization
     /// <param name="x"> The operand elements. </param>
     /// <param name="ans"> The destination of answer. </param>
     /// <exception cref="ArgumentException"> <paramref name="x"/> and <paramref name="ans"/> must have same length. </exception>
+    [GeneratedCode("T4", null)]
     public void Widen(ReadOnlySpan<byte> x, Span<ushort> ans)
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        WidenCore(x, ans);
+        unsafe
+        {
+            WidenCore(x, ans);
+        }
     }
     
     /// <summary>
@@ -433,7 +455,8 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    protected internal virtual void WidenCore(ReadOnlySpan<byte> x, Span<ushort> ans)
+    [GeneratedCode("T4", null), UnsafeApi]
+    protected internal virtual unsafe void WidenCore(ReadOnlySpan<byte> x, Span<ushort> ans)
     {
         for (var i = 0; i < ans.Length; ++i)
             ans[i] = (ushort)x[i];
@@ -443,6 +466,7 @@ partial class Vectorization
 partial class SimdVectorization
 {
     /// <inheritdoc />
+    [GeneratedCode("T4", null)]
     protected internal override sealed void WidenCore(ReadOnlySpan<byte> x, Span<ushort> ans)
     {
         var vectorX = MemoryMarshal.Cast<byte, Vector<byte>>(x);
@@ -475,11 +499,15 @@ partial class Vectorization
     /// <param name="x"> The operand elements. </param>
     /// <param name="ans"> The destination of answer. </param>
     /// <exception cref="ArgumentException"> <paramref name="x"/> and <paramref name="ans"/> must have same length. </exception>
+    [GeneratedCode("T4", null)]
     public void Widen(ReadOnlySpan<ushort> x, Span<uint> ans)
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        WidenCore(x, ans);
+        unsafe
+        {
+            WidenCore(x, ans);
+        }
     }
     
     /// <summary>
@@ -495,7 +523,8 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    protected internal virtual void WidenCore(ReadOnlySpan<ushort> x, Span<uint> ans)
+    [GeneratedCode("T4", null), UnsafeApi]
+    protected internal virtual unsafe void WidenCore(ReadOnlySpan<ushort> x, Span<uint> ans)
     {
         for (var i = 0; i < ans.Length; ++i)
             ans[i] = (uint)x[i];
@@ -505,6 +534,7 @@ partial class Vectorization
 partial class SimdVectorization
 {
     /// <inheritdoc />
+    [GeneratedCode("T4", null)]
     protected internal override sealed void WidenCore(ReadOnlySpan<ushort> x, Span<uint> ans)
     {
         var vectorX = MemoryMarshal.Cast<ushort, Vector<ushort>>(x);
@@ -537,11 +567,15 @@ partial class Vectorization
     /// <param name="x"> The operand elements. </param>
     /// <param name="ans"> The destination of answer. </param>
     /// <exception cref="ArgumentException"> <paramref name="x"/> and <paramref name="ans"/> must have same length. </exception>
+    [GeneratedCode("T4", null)]
     public void Widen(ReadOnlySpan<uint> x, Span<ulong> ans)
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        WidenCore(x, ans);
+        unsafe
+        {
+            WidenCore(x, ans);
+        }
     }
     
     /// <summary>
@@ -557,7 +591,8 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    protected internal virtual void WidenCore(ReadOnlySpan<uint> x, Span<ulong> ans)
+    [GeneratedCode("T4", null), UnsafeApi]
+    protected internal virtual unsafe void WidenCore(ReadOnlySpan<uint> x, Span<ulong> ans)
     {
         for (var i = 0; i < ans.Length; ++i)
             ans[i] = (ulong)x[i];
@@ -567,6 +602,7 @@ partial class Vectorization
 partial class SimdVectorization
 {
     /// <inheritdoc />
+    [GeneratedCode("T4", null)]
     protected internal override sealed void WidenCore(ReadOnlySpan<uint> x, Span<ulong> ans)
     {
         var vectorX = MemoryMarshal.Cast<uint, Vector<uint>>(x);
@@ -599,11 +635,15 @@ partial class Vectorization
     /// <param name="x"> The operand elements. </param>
     /// <param name="ans"> The destination of answer. </param>
     /// <exception cref="ArgumentException"> <paramref name="x"/> and <paramref name="ans"/> must have same length. </exception>
+    [GeneratedCode("T4", null)]
     public void Widen(ReadOnlySpan<sbyte> x, Span<short> ans)
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        WidenCore(x, ans);
+        unsafe
+        {
+            WidenCore(x, ans);
+        }
     }
     
     /// <summary>
@@ -619,7 +659,8 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    protected internal virtual void WidenCore(ReadOnlySpan<sbyte> x, Span<short> ans)
+    [GeneratedCode("T4", null), UnsafeApi]
+    protected internal virtual unsafe void WidenCore(ReadOnlySpan<sbyte> x, Span<short> ans)
     {
         for (var i = 0; i < ans.Length; ++i)
             ans[i] = (short)x[i];
@@ -629,6 +670,7 @@ partial class Vectorization
 partial class SimdVectorization
 {
     /// <inheritdoc />
+    [GeneratedCode("T4", null)]
     protected internal override sealed void WidenCore(ReadOnlySpan<sbyte> x, Span<short> ans)
     {
         var vectorX = MemoryMarshal.Cast<sbyte, Vector<sbyte>>(x);
@@ -661,11 +703,15 @@ partial class Vectorization
     /// <param name="x"> The operand elements. </param>
     /// <param name="ans"> The destination of answer. </param>
     /// <exception cref="ArgumentException"> <paramref name="x"/> and <paramref name="ans"/> must have same length. </exception>
+    [GeneratedCode("T4", null)]
     public void Widen(ReadOnlySpan<short> x, Span<int> ans)
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        WidenCore(x, ans);
+        unsafe
+        {
+            WidenCore(x, ans);
+        }
     }
     
     /// <summary>
@@ -681,7 +727,8 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    protected internal virtual void WidenCore(ReadOnlySpan<short> x, Span<int> ans)
+    [GeneratedCode("T4", null), UnsafeApi]
+    protected internal virtual unsafe void WidenCore(ReadOnlySpan<short> x, Span<int> ans)
     {
         for (var i = 0; i < ans.Length; ++i)
             ans[i] = (int)x[i];
@@ -691,6 +738,7 @@ partial class Vectorization
 partial class SimdVectorization
 {
     /// <inheritdoc />
+    [GeneratedCode("T4", null)]
     protected internal override sealed void WidenCore(ReadOnlySpan<short> x, Span<int> ans)
     {
         var vectorX = MemoryMarshal.Cast<short, Vector<short>>(x);
@@ -723,11 +771,15 @@ partial class Vectorization
     /// <param name="x"> The operand elements. </param>
     /// <param name="ans"> The destination of answer. </param>
     /// <exception cref="ArgumentException"> <paramref name="x"/> and <paramref name="ans"/> must have same length. </exception>
+    [GeneratedCode("T4", null)]
     public void Widen(ReadOnlySpan<int> x, Span<long> ans)
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        WidenCore(x, ans);
+        unsafe
+        {
+            WidenCore(x, ans);
+        }
     }
     
     /// <summary>
@@ -743,7 +795,8 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    protected internal virtual void WidenCore(ReadOnlySpan<int> x, Span<long> ans)
+    [GeneratedCode("T4", null), UnsafeApi]
+    protected internal virtual unsafe void WidenCore(ReadOnlySpan<int> x, Span<long> ans)
     {
         for (var i = 0; i < ans.Length; ++i)
             ans[i] = (long)x[i];
@@ -753,6 +806,7 @@ partial class Vectorization
 partial class SimdVectorization
 {
     /// <inheritdoc />
+    [GeneratedCode("T4", null)]
     protected internal override sealed void WidenCore(ReadOnlySpan<int> x, Span<long> ans)
     {
         var vectorX = MemoryMarshal.Cast<int, Vector<int>>(x);

--- a/src/SmartVectorDotNet/Vectorization/Vectorization._NarrowWiden.tt
+++ b/src/SmartVectorDotNet/Vectorization/Vectorization._NarrowWiden.tt
@@ -54,7 +54,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        NarrowCore(x, ans);
+        unsafe
+        {
+            NarrowCore(x, ans);
+        }
     }
     
     /// <summary>
@@ -70,8 +73,8 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
-    protected internal virtual void NarrowCore(ReadOnlySpan<<#=method.TFrom#>> x, Span<<#=method.TTo#>> ans)
+    [GeneratedCode("T4", null), UnsafeApi]
+    protected internal virtual unsafe void NarrowCore(ReadOnlySpan<<#=method.TFrom#>> x, Span<<#=method.TTo#>> ans)
     {
         for (var i = 0; i < ans.Length; ++i)
             ans[i] = (<#=method.TTo#>)x[i];
@@ -117,11 +120,15 @@ partial class Vectorization
     /// <param name="x"> The operand elements. </param>
     /// <param name="ans"> The destination of answer. </param>
     /// <exception cref="ArgumentException"> <paramref name="x"/> and <paramref name="ans"/> must have same length. </exception>
+    [GeneratedCode("T4", null)]
     public void Widen(ReadOnlySpan<<#=method.TFrom#>> x, Span<<#=method.TTo#>> ans)
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        WidenCore(x, ans);
+        unsafe
+        {
+            WidenCore(x, ans);
+        }
     }
     
     /// <summary>
@@ -137,7 +144,8 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    protected internal virtual void WidenCore(ReadOnlySpan<<#=method.TFrom#>> x, Span<<#=method.TTo#>> ans)
+    [GeneratedCode("T4", null), UnsafeApi]
+    protected internal virtual unsafe void WidenCore(ReadOnlySpan<<#=method.TFrom#>> x, Span<<#=method.TTo#>> ans)
     {
         for (var i = 0; i < ans.Length; ++i)
             ans[i] = (<#=method.TTo#>)x[i];
@@ -147,6 +155,7 @@ partial class Vectorization
 partial class SimdVectorization
 {
     /// <inheritdoc />
+    [GeneratedCode("T4", null)]
     protected internal override sealed void WidenCore(ReadOnlySpan<<#=method.TFrom#>> x, Span<<#=method.TTo#>> ans)
     {
         var vectorX = MemoryMarshal.Cast<<#=method.TFrom#>, Vector<<#=method.TFrom#>>>(x);

--- a/src/SmartVectorDotNet/Vectorization/Vectorization._Unary.g.cs
+++ b/src/SmartVectorDotNet/Vectorization/Vectorization._Unary.g.cs
@@ -29,7 +29,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        UnaryPlusCore(x, ans);
+        unsafe
+        {
+            UnaryPlusCore(x, ans);
+        }
     }
 
     /// <summary>
@@ -47,7 +50,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void UnaryPlusCore<T>(ReadOnlySpan<T> x, Span<T> ans)
         where T : unmanaged
     {
@@ -100,7 +103,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        UnaryMinusCore(x, ans);
+        unsafe
+        {
+            UnaryMinusCore(x, ans);
+        }
     }
 
     /// <summary>
@@ -118,7 +124,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void UnaryMinusCore<T>(ReadOnlySpan<T> x, Span<T> ans)
         where T : unmanaged
     {
@@ -171,7 +177,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(x.Length == ans.Length, "`x` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref x, ans);
-        ComplementCore(x, ans);
+        unsafe
+        {
+            ComplementCore(x, ans);
+        }
     }
 
     /// <summary>
@@ -189,7 +198,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void ComplementCore<T>(ReadOnlySpan<T> x, Span<T> ans)
         where T : unmanaged
     {
@@ -242,7 +251,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        AbsCore(d, ans);
+        unsafe
+        {
+            AbsCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -260,7 +272,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void AbsCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -313,7 +325,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        AcosCore(d, ans);
+        unsafe
+        {
+            AcosCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -331,7 +346,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void AcosCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -384,7 +399,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        AcoshCore(d, ans);
+        unsafe
+        {
+            AcoshCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -402,7 +420,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void AcoshCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -455,7 +473,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        AsinCore(d, ans);
+        unsafe
+        {
+            AsinCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -473,7 +494,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void AsinCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -526,7 +547,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        AsinhCore(d, ans);
+        unsafe
+        {
+            AsinhCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -544,7 +568,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void AsinhCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -597,7 +621,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        AtanCore(d, ans);
+        unsafe
+        {
+            AtanCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -615,7 +642,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void AtanCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -668,7 +695,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        AtanhCore(d, ans);
+        unsafe
+        {
+            AtanhCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -686,7 +716,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void AtanhCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -739,7 +769,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        CbrtCore(d, ans);
+        unsafe
+        {
+            CbrtCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -757,7 +790,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void CbrtCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -810,7 +843,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        CeilingCore(d, ans);
+        unsafe
+        {
+            CeilingCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -828,7 +864,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void CeilingCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -881,7 +917,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        CosCore(d, ans);
+        unsafe
+        {
+            CosCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -899,7 +938,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void CosCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -952,7 +991,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        CoshCore(d, ans);
+        unsafe
+        {
+            CoshCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -970,7 +1012,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void CoshCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -1023,7 +1065,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        ExpCore(d, ans);
+        unsafe
+        {
+            ExpCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -1041,7 +1086,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void ExpCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -1094,7 +1139,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        FloorCore(d, ans);
+        unsafe
+        {
+            FloorCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -1112,7 +1160,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void FloorCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -1165,7 +1213,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        LogCore(d, ans);
+        unsafe
+        {
+            LogCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -1183,7 +1234,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void LogCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -1236,7 +1287,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        Log10Core(d, ans);
+        unsafe
+        {
+            Log10Core(d, ans);
+        }
     }
 
     /// <summary>
@@ -1254,7 +1308,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void Log10Core<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -1307,7 +1361,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        Log2Core(d, ans);
+        unsafe
+        {
+            Log2Core(d, ans);
+        }
     }
 
     /// <summary>
@@ -1325,7 +1382,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void Log2Core<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -1378,7 +1435,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        RoundCore(d, ans);
+        unsafe
+        {
+            RoundCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -1396,7 +1456,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void RoundCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -1449,7 +1509,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        SignCore(d, ans);
+        unsafe
+        {
+            SignCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -1467,7 +1530,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void SignCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -1520,7 +1583,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        SinCore(d, ans);
+        unsafe
+        {
+            SinCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -1538,7 +1604,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void SinCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -1591,7 +1657,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        SinhCore(d, ans);
+        unsafe
+        {
+            SinhCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -1609,7 +1678,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void SinhCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -1662,7 +1731,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        SqrtCore(d, ans);
+        unsafe
+        {
+            SqrtCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -1680,7 +1752,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void SqrtCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -1733,7 +1805,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        TanCore(d, ans);
+        unsafe
+        {
+            TanCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -1751,7 +1826,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void TanCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -1804,7 +1879,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        TanhCore(d, ans);
+        unsafe
+        {
+            TanhCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -1822,7 +1900,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void TanhCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {
@@ -1875,7 +1953,10 @@ partial class Vectorization
     {
         Guard.ValidArgument(d.Length == ans.Length, "`d` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref d, ans);
-        TruncateCore(d, ans);
+        unsafe
+        {
+            TruncateCore(d, ans);
+        }
     }
 
     /// <summary>
@@ -1893,7 +1974,7 @@ partial class Vectorization
     /// <item> there are no offseted overlap between input and output (it means writing to the same index is safe) </item>
     /// </list>
     /// </remarks>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void TruncateCore<T>(ReadOnlySpan<T> d, Span<T> ans)
         where T : unmanaged
     {

--- a/src/SmartVectorDotNet/Vectorization/Vectorization._Unary.tt
+++ b/src/SmartVectorDotNet/Vectorization/Vectorization._Unary.tt
@@ -65,11 +65,14 @@ partial class Vectorization
     {
         Guard.ValidArgument(<#=arg1#>.Length == ans.Length, "`<#=arg1#>` and `ans` must have same length.");
         using var safeXBuffer = EnsureSourceSafe(ref <#=arg1#>, ans);
-        <#=methodName#>Core(<#=arg1#>, ans);
+        unsafe
+        {
+            <#=methodName#>Core(<#=arg1#>, ans);
+        }
     }
 
     <# DocumentCore(methodName, $"{methodName}{{T}}(ReadOnlySpan{{T}}, Span{{T}})", arg1); #>
-    [GeneratedCode("T4", null)]
+    [GeneratedCode("T4", null), UnsafeApi]
     protected internal virtual void <#=methodName#>Core<T>(ReadOnlySpan<T> <#=arg1#>, Span<T> ans)
         where T : unmanaged
     {

--- a/src/SmartVectorDotNet/Vectorization/Vectorization.cs
+++ b/src/SmartVectorDotNet/Vectorization/Vectorization.cs
@@ -1,10 +1,8 @@
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace SmartVectorDotNet;
+using H = InternalHelpers;
 
 /// <summary>
 /// Provides abstraction of vectorized primitive operations.
@@ -36,15 +34,11 @@ public partial class Vectorization
         where T1 : unmanaged
         where T2 : unmanaged
     {
-        static ref byte getUntypedRef<T>(in T reference)
-            => ref Unsafe.As<T, byte>(ref Unsafe.AsRef(in reference));
-
-        static bool isSameBuffer(ReadOnlySpan<T1> source, Span<T2> destination)
-            => Unsafe.SizeOf<T1>() == Unsafe.SizeOf<T2>()
-            && Unsafe.ByteOffset(ref getUntypedRef(source[0]), ref getUntypedRef(destination[0])) == IntPtr.Zero;
-
-        static bool hasOverlap(ReadOnlySpan<T1> source, Span<T2> destination)
+        static unsafe bool hasOverlap(ReadOnlySpan<T1> source, Span<T2> destination)
         {
+            static ref byte getUntypedRef<T>(in T reference)
+                => ref Unsafe.As<T, byte>(ref Unsafe.AsRef(in reference));
+
             IntPtr s0, s1, d0, d1;
             do
             {
@@ -72,7 +66,7 @@ public partial class Vectorization
         {
             return default;
         }
-        if (isSameBuffer(source, destination))
+        if (H.IsSameBuffer(source, destination))
         {
             return default;
         }

--- a/tests/SmartVectorDotNet.Test/InternalHelpersTest.cs
+++ b/tests/SmartVectorDotNet.Test/InternalHelpersTest.cs
@@ -85,21 +85,18 @@ public unsafe partial class InternalHelpersTest
     }
 
     [Fact]
-    public void Reinterpret_Single()
+    public void BitCast_Single()
     {
         int x = 42;
-        ref readonly float y = ref InternalHelpers.Reinterpret<int, float>(in x);
+        float y = InternalHelpers.BitCast<int, float>(x);
         Assert.Equal(Unsafe.BitCast<int, float>(x), y);
-        var ptrX = (nint)Unsafe.AsPointer(ref x);
-        var ptrY = (nint)Unsafe.AsPointer(ref Unsafe.AsRef(in y));
-        Assert.Equal(ptrX, ptrY);
     }
 
     [Fact]
-    public void ReinterpretMutable_Single()
+    public void Reinterpret_Single()
     {
         int x = 42;
-        ref float y = ref InternalHelpers.ReinterpretMutable<int, float>(ref x);
+        ref float y = ref InternalHelpers.Reinterpret<int, float>(ref x);
         Assert.Equal(Unsafe.BitCast<int, float>(x), y);
         var ptrX = (nint)Unsafe.AsPointer(ref x);
         var ptrY = (nint)Unsafe.AsPointer(ref y);
@@ -107,21 +104,18 @@ public unsafe partial class InternalHelpersTest
     }
 
     [Fact]
-    public void Reinterpret_Vector()
+    public void BitCast_Vector()
     {
         Vector<int> x = new(42);
-        ref readonly Vector<float> y = ref InternalHelpers.Reinterpret<int, float>(in x);
+        Vector<float> y = InternalHelpers.BitCastV<int, float>(x);
         Assert.Equal(Vector.AsVectorSingle(x), y);
-        var ptrX = (nint)Unsafe.AsPointer(ref x);
-        var ptrY = (nint)Unsafe.AsPointer(ref Unsafe.AsRef(in y));
-        Assert.Equal(ptrX, ptrY);
     }
 
     [Fact]
-    public void ReinterpretMutable_Vector()
+    public void Reinterpret_Vector()
     {
         Vector<int> x = new(42);
-        ref Vector<float> y = ref InternalHelpers.ReinterpretMutable<int, float>(ref x);
+        ref Vector<float> y = ref InternalHelpers.ReinterpretV<int, float>(ref x);
         Assert.Equal(Vector.AsVectorSingle(x), y);
         var ptrX = new nint(Unsafe.AsPointer(ref x));
         var ptrY = new nint(Unsafe.AsPointer(ref y));
@@ -129,25 +123,19 @@ public unsafe partial class InternalHelpersTest
     }
 
     [Fact]
-    public void Reinterpret_Vector256()
+    public void BitCast_Vector256()
     {
         Vector256<int> x = Vector256.Create(42);
-        ref readonly Vector256<float> y = ref InternalHelpers.Reinterpret<int, float>(in x);
+        Vector256<float> y = InternalHelpers.BitCast<int, float>(x);
         Assert.Equal(Vector256.AsSingle(x), y);
-        var ptrX = (nint)Unsafe.AsPointer(ref x);
-        var ptrY = (nint)Unsafe.AsPointer(ref Unsafe.AsRef(in y));
-        Assert.Equal(ptrX, ptrY);
     }
 
     [Fact]
-    public void Reinterpret_Vector128()
+    public void BitCast_Vector128()
     {
         Vector128<int> x = Vector128.Create(42);
-        ref readonly Vector128<float> y = ref InternalHelpers.Reinterpret<int, float>(in x);
+        Vector128<float> y = InternalHelpers.BitCast<int, float>(x);
         Assert.Equal(Vector128.AsSingle(x), y);
-        var ptrX = (nint)Unsafe.AsPointer(ref x);
-        var ptrY = (nint)Unsafe.AsPointer(ref Unsafe.AsRef(in y));
-        Assert.Equal(ptrX, ptrY);
     }
 
     [Fact]
@@ -163,7 +151,7 @@ public unsafe partial class InternalHelpersTest
         static void core<T>(Vector<int>[] x)
             where T : unmanaged
         {
-            ref readonly Vector<T>[] y = ref InternalHelpers.ReinterpretVArray<int, T>(in x);
+            Vector<T>[] y = InternalHelpers.ReinterpretVArray<int, T>(x);
             for(var i = 0; i < x.Length; i++)
             {
                 Assert.Equal(Unsafe.As<Vector<int>, Vector<T>>(ref x[i]), y[i]);
@@ -175,7 +163,7 @@ public unsafe partial class InternalHelpersTest
     public void AsUnsigned08U()
     {
         Vector<byte> x = new (byte.MaxValue);
-        ref readonly Vector<byte> y = ref InternalHelpers.AsUnsigned(in x);
+        Vector<byte> y = InternalHelpers.AsUnsigned(x);
         Assert.Equal(x[0], y[0]);
     }
 
@@ -183,7 +171,7 @@ public unsafe partial class InternalHelpersTest
     public void AsUnsigned16U()
     {
         Vector<ushort> x = new(ushort.MaxValue);
-        ref readonly Vector<ushort> y = ref InternalHelpers.AsUnsigned(in x);
+        Vector<ushort> y = InternalHelpers.AsUnsigned(x);
         Assert.Equal(x[0], y[0]);
     }
 
@@ -191,7 +179,7 @@ public unsafe partial class InternalHelpersTest
     public void AsUnsigned32U()
     {
         Vector<uint> x = new(uint.MaxValue);
-        ref readonly Vector<uint> y = ref InternalHelpers.AsUnsigned(in x);
+        Vector<uint> y = InternalHelpers.AsUnsigned(x);
         Assert.Equal(x[0], y[0]);
     }
 
@@ -199,7 +187,7 @@ public unsafe partial class InternalHelpersTest
     public void AsUnsigned64U()
     {
         Vector<ulong> x = new(ulong.MaxValue);
-        ref readonly Vector<ulong> y = ref InternalHelpers.AsUnsigned(in x);
+        Vector<ulong> y = InternalHelpers.AsUnsigned(x);
         Assert.Equal(x[0], y[0]);
     }
 
@@ -207,7 +195,7 @@ public unsafe partial class InternalHelpersTest
     public void AsUnsignedNU()
     {
         Vector<nuint> x = new(nuint.MaxValue);
-        ref readonly Vector<nuint> y = ref InternalHelpers.AsUnsigned(in x);
+        Vector<nuint> y = InternalHelpers.AsUnsigned(x);
         Assert.Equal(x[0], y[0]);
     }
 
@@ -215,7 +203,7 @@ public unsafe partial class InternalHelpersTest
     public void AsUnsigned08I()
     {
         Vector<sbyte> x = new(sbyte.MaxValue);
-        ref readonly Vector<byte> y = ref InternalHelpers.AsUnsigned(in x);
+        Vector<byte> y = InternalHelpers.AsUnsigned(x);
         Assert.Equal((byte)x[0], y[0]);
     }
 
@@ -223,7 +211,7 @@ public unsafe partial class InternalHelpersTest
     public void AsUnsigned16I()
     {
         Vector<short> x = new(short.MaxValue);
-        ref readonly Vector<ushort> y = ref InternalHelpers.AsUnsigned(in x);
+        Vector<ushort> y = InternalHelpers.AsUnsigned(x);
         Assert.Equal((ushort)x[0], y[0]);
     }
 
@@ -231,7 +219,7 @@ public unsafe partial class InternalHelpersTest
     public void AsUnsigned32I()
     {
         Vector<int> x = new(int.MaxValue);
-        ref readonly Vector<uint> y = ref InternalHelpers.AsUnsigned(in x);
+        Vector<uint> y = InternalHelpers.AsUnsigned(x);
         Assert.Equal((uint)x[0], y[0]);
     }
 
@@ -239,7 +227,7 @@ public unsafe partial class InternalHelpersTest
     public void AsUnsigned64I()
     {
         Vector<long> x = new(long.MaxValue);
-        ref readonly Vector<ulong> y = ref InternalHelpers.AsUnsigned(in x);
+        Vector<ulong> y = InternalHelpers.AsUnsigned(x);
         Assert.Equal((ulong)x[0], y[0]);
     }
 
@@ -247,7 +235,7 @@ public unsafe partial class InternalHelpersTest
     public void AsUnsignedNI()
     {
         Vector<nint> x = new(nint.MaxValue);
-        ref readonly Vector<nuint> y = ref InternalHelpers.AsUnsigned(in x);
+        Vector<nuint> y = InternalHelpers.AsUnsigned(x);
         Assert.Equal((nuint)x[0], y[0]);
     }
 
@@ -255,7 +243,7 @@ public unsafe partial class InternalHelpersTest
     public void AsSigned08U()
     {
         Vector<byte> x = new(byte.MaxValue);
-        ref readonly Vector<sbyte> y = ref InternalHelpers.AsSigned(in x);
+        Vector<sbyte> y = InternalHelpers.AsSigned(x);
         Assert.Equal((sbyte)x[0], y[0]);
     }
 
@@ -263,7 +251,7 @@ public unsafe partial class InternalHelpersTest
     public void AsSigned16U()
     {
         Vector<ushort> x = new(ushort.MaxValue);
-        ref readonly Vector<short> y = ref InternalHelpers.AsSigned(in x);
+        Vector<short> y = InternalHelpers.AsSigned(x);
         Assert.Equal((short)x[0], y[0]);
     }
 
@@ -271,7 +259,7 @@ public unsafe partial class InternalHelpersTest
     public void AsSigned32U()
     {
         Vector<uint> x = new(uint.MaxValue);
-        ref readonly Vector<int> y = ref InternalHelpers.AsSigned(in x);
+        Vector<int> y = InternalHelpers.AsSigned(x);
         Assert.Equal((int)x[0], y[0]);
     }
 
@@ -279,7 +267,7 @@ public unsafe partial class InternalHelpersTest
     public void AsSigned64U()
     {
         Vector<ulong> x = new(ulong.MaxValue);
-        ref readonly Vector<long> y = ref InternalHelpers.AsSigned(in x);
+        Vector<long> y = InternalHelpers.AsSigned(x);
         Assert.Equal((long)x[0], y[0]);
     }
 
@@ -287,7 +275,7 @@ public unsafe partial class InternalHelpersTest
     public void AsSignedNU()
     {
         Vector<nuint> x = new(nuint.MaxValue);
-        ref readonly Vector<nint> y = ref InternalHelpers.AsSigned(in x);
+        Vector<nint> y = InternalHelpers.AsSigned(x);
         Assert.Equal((nint)x[0], y[0]);
     }
 
@@ -295,7 +283,7 @@ public unsafe partial class InternalHelpersTest
     public void AsSigned08I()
     {
         Vector<sbyte> x = new(sbyte.MaxValue);
-        ref readonly Vector<sbyte> y = ref InternalHelpers.AsSigned(in x);
+        Vector<sbyte> y = InternalHelpers.AsSigned(x);
         Assert.Equal(x[0], y[0]);
     }
 
@@ -303,7 +291,7 @@ public unsafe partial class InternalHelpersTest
     public void AsSigned16I()
     {
         Vector<short> x = new(short.MaxValue);
-        ref readonly Vector<short> y = ref InternalHelpers.AsSigned(in x);
+        Vector<short> y = InternalHelpers.AsSigned(x);
         Assert.Equal(x[0], y[0]);
     }
 
@@ -311,7 +299,7 @@ public unsafe partial class InternalHelpersTest
     public void AsSigned32I()
     {
         Vector<int> x = new(int.MaxValue);
-        ref readonly Vector<int> y = ref InternalHelpers.AsSigned(in x);
+        Vector<int> y = InternalHelpers.AsSigned(x);
         Assert.Equal(x[0], y[0]);
     }
 
@@ -319,7 +307,7 @@ public unsafe partial class InternalHelpersTest
     public void AsSigned64I()
     {
         Vector<long> x = new(long.MaxValue);
-        ref readonly Vector<long> y = ref InternalHelpers.AsSigned(in x);
+        Vector<long> y = InternalHelpers.AsSigned(x);
         Assert.Equal(x[0], y[0]);
     }
 
@@ -327,7 +315,7 @@ public unsafe partial class InternalHelpersTest
     public void AsSignedNI()
     {
         Vector<nint> x = new(nint.MaxValue);
-        ref readonly Vector<nint> y = ref InternalHelpers.AsSigned(in x);
+        Vector<nint> y = InternalHelpers.AsSigned(x);
         Assert.Equal(x[0], y[0]);
     }
 }

--- a/tests/SmartVectorDotNet.Test/ScalarOpTest/ScalarOpTest._Operator.cs
+++ b/tests/SmartVectorDotNet.Test/ScalarOpTest/ScalarOpTest._Operator.cs
@@ -101,8 +101,8 @@ public partial class ScalarOpTest
             yield return TestCase<int   >(true, 123, (int   )~(int   )123);
             yield return TestCase<long  >(true, 123, (long  )~(long  )123);
             yield return TestCase<nint  >(true, 123, (nint  )~(nint  )123);
-            yield return TestCase<float >(true, 1.23f, H.Reinterpret<uint , float >(~H.Reinterpret<float , uint >(1.23f)));
-            yield return TestCase<double>(true, 1.23 , H.Reinterpret<ulong, double>(~H.Reinterpret<double, ulong>(1.23 )));
+            yield return TestCase<float >(true, 1.23f, H.BitCast<uint , float >(~H.BitCast<float , uint >(1.23f)));
+            yield return TestCase<double>(true, 1.23 , H.BitCast<ulong, double>(~H.BitCast<double, ulong>(1.23 )));
         }
 #pragma warning restore format
     }
@@ -371,8 +371,8 @@ public partial class ScalarOpTest
             yield return TestCase<int   >(true, (12, 34), (int   )(12 & 34));
             yield return TestCase<long  >(true, (12, 34), (long  )(12 & 34));
             yield return TestCase<nint  >(true, (12, 34), (nint  )(12 & 34));
-            yield return TestCase<float >(true, (12.345f, 67.890f), H.Reinterpret<int , float >(H.Reinterpret<float , int >(12.345f) & H.Reinterpret<float , int >(67.890f)));
-            yield return TestCase<double>(true, (12.345 , 67.890 ), H.Reinterpret<long, double>(H.Reinterpret<double, long>(12.345 ) & H.Reinterpret<double, long>(67.890 )));
+            yield return TestCase<float >(true, (12.345f, 67.890f), H.BitCast<int , float >(H.BitCast<float , int >(12.345f) & H.BitCast<float , int >(67.890f)));
+            yield return TestCase<double>(true, (12.345 , 67.890 ), H.BitCast<long, double>(H.BitCast<double, long>(12.345 ) & H.BitCast<double, long>(67.890 )));
         }
 #pragma warning restore format
     }
@@ -398,8 +398,8 @@ public partial class ScalarOpTest
             yield return TestCase<int   >(true, (12, 34), (int   )(12 | 34));
             yield return TestCase<long  >(true, (12, 34), (long  )(12 | 34));
             yield return TestCase<nint  >(true, (12, 34), (nint  )(12 | 34));
-            yield return TestCase<float >(true, (12.345f, 67.890f), H.Reinterpret<uint , float >(H.Reinterpret<float , uint >(12.345f) | H.Reinterpret<float , uint >(67.890f)));
-            yield return TestCase<double>(true, (12.345 , 67.890 ), H.Reinterpret<ulong, double>(H.Reinterpret<double, ulong>(12.345 ) | H.Reinterpret<double, ulong>(67.890 )));
+            yield return TestCase<float >(true, (12.345f, 67.890f), H.BitCast<uint , float >(H.BitCast<float , uint >(12.345f) | H.BitCast<float , uint >(67.890f)));
+            yield return TestCase<double>(true, (12.345 , 67.890 ), H.BitCast<ulong, double>(H.BitCast<double, ulong>(12.345 ) | H.BitCast<double, ulong>(67.890 )));
         }
 #pragma warning restore format
     }
@@ -425,8 +425,8 @@ public partial class ScalarOpTest
             yield return TestCase<int   >(true, (12, 34), (int   )(12 ^ 34));
             yield return TestCase<long  >(true, (12, 34), (long  )(12 ^ 34));
             yield return TestCase<nint  >(true, (12, 34), (nint  )(12 ^ 34));
-            yield return TestCase<float >(true, (12.345f, 67.890f), H.Reinterpret<uint , float >(H.Reinterpret<float , uint >(12.345f) ^ H.Reinterpret<float , uint >(67.890f)));
-            yield return TestCase<double>(true, (12.345 , 67.890 ), H.Reinterpret<ulong, double>(H.Reinterpret<double, ulong>(12.345 ) ^ H.Reinterpret<double, ulong>(67.890 )));
+            yield return TestCase<float >(true, (12.345f, 67.890f), H.BitCast<uint , float >(H.BitCast<float , uint >(12.345f) ^ H.BitCast<float , uint >(67.890f)));
+            yield return TestCase<double>(true, (12.345 , 67.890 ), H.BitCast<ulong, double>(H.BitCast<double, ulong>(12.345 ) ^ H.BitCast<double, ulong>(67.890 )));
         }
 #pragma warning restore format
     }
@@ -451,8 +451,8 @@ public partial class ScalarOpTest
         yield return TestCaseEx<int   , int, int   >(true, (12, 3), 12 << 3);
         yield return TestCaseEx<long  , int, long  >(true, (12, 3), 12 << 3);
         yield return TestCaseEx<nint  , int, nint  >(true, (12, 3), 12 << 3);
-        yield return TestCaseEx<float , int, float >(true, (-12f , 3), H.Reinterpret<int , float >(H.Reinterpret<float , int >(-12f ) << 3));
-        yield return TestCaseEx<double, int, double>(true, (-12.0, 3), H.Reinterpret<long, double>(H.Reinterpret<double, long>(-12.0) << 3));
+        yield return TestCaseEx<float , int, float >(true, (-12f , 3), H.BitCast<int , float >(H.BitCast<float , int >(-12f ) << 3));
+        yield return TestCaseEx<double, int, double>(true, (-12.0, 3), H.BitCast<long, double>(H.BitCast<double, long>(-12.0) << 3));
 #pragma warning restore format
     }
     [Theory, MemberData(nameof(ShiftLeftTestCases))]
@@ -476,8 +476,8 @@ public partial class ScalarOpTest
         yield return TestCaseEx<int   , int, int   >(true, (12, 3), 12 >> 3);
         yield return TestCaseEx<long  , int, long  >(true, (12, 3), 12 >> 3);
         yield return TestCaseEx<nint  , int, nint  >(true, (12, 3), 12 >> 3);
-        yield return TestCaseEx<float , int, float >(true, (-12f , 3), H.Reinterpret<int , float >(H.Reinterpret<float , int >(-12f ) >> 3));
-        yield return TestCaseEx<double, int, double>(true, (-12.0, 3), H.Reinterpret<long, double>(H.Reinterpret<double, long>(-12.0) >> 3));
+        yield return TestCaseEx<float , int, float >(true, (-12f , 3), H.BitCast<int , float >(H.BitCast<float , int >(-12f ) >> 3));
+        yield return TestCaseEx<double, int, double>(true, (-12.0, 3), H.BitCast<long, double>(H.BitCast<double, long>(-12.0) >> 3));
 #pragma warning restore format
     }
     [Theory, MemberData(nameof(ShiftRightTestCases))]

--- a/tests/SmartVectorDotNet.Test/VectorOpTest/VectorOpTest._BitOperations.CountPopulation.cs
+++ b/tests/SmartVectorDotNet.Test/VectorOpTest/VectorOpTest._BitOperations.CountPopulation.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualBasic;
@@ -17,11 +18,9 @@ public partial class VectorOpTest
         static void core<T>(IEnumerable<T> testValues)
             where T : unmanaged
         {
-            var buf = (stackalloc T[Vector<T>.Count]);
-            var testVector = InternalHelpers.BitCast<T, Vector<T>>(buf[0]);
             foreach (var testValue in testValues)
             {
-                buf[0] = testValue;
+                var testVector = new Vector<T>(testValue);
                 Assert.Equal(
                     ScalarOp.CountPopulation(testValue),
                     VectorOp.CountPopulation(testVector)[0]);

--- a/tests/SmartVectorDotNet.Test/VectorOpTest/VectorOpTest._BitOperations.CountPopulation.cs
+++ b/tests/SmartVectorDotNet.Test/VectorOpTest/VectorOpTest._BitOperations.CountPopulation.cs
@@ -18,7 +18,7 @@ public partial class VectorOpTest
             where T : unmanaged
         {
             var buf = (stackalloc T[Vector<T>.Count]);
-            ref readonly var testVector = ref InternalHelpers.Reinterpret<T, Vector<T>>(buf[0]);
+            var testVector = InternalHelpers.BitCast<T, Vector<T>>(buf[0]);
             foreach (var testValue in testValues)
             {
                 buf[0] = testValue;


### PR DESCRIPTION
The current C# allows use of unsafe APIs without an explicit unsafe context, but that does not constitute a sufficient declaration of intent to guarantee the code's memory safety.
This PR clarifies the intent regarding memory safety by requiring an unsafe context when using unsafe APIs.
